### PR TITLE
fix(scripts): replace hardcoded Ollama paths with dynamic PATH resolution

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -504,6 +504,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 7 | 2026-04-25 | TASK-T17 | major | 3 arquivos — .github/workflows/ci.yml, requirements.txt | aprovado | CI com 4 jobs: lint, test, validate-requirements, typecheck |
 | 8 | 2026-04-25 | TASK-T24 | major | 4 arquivos — core/config.py, database/models.py, retrieval/vector_store.py, tests/ | aprovado | Auditoria Clean Code + fixes (datetime.UTC, remoção alias) |
 | 9 | 2026-04-25 | TASK-T25 | minor | 6 arquivos — SETUP.md, .env.example, core/, retrieval/, database/, tests/ | aprovado | Guia setup local/remoto + suporte QDRANT_API_KEY |
+| 10 | 2026-04-25 | TASK-T26 | patch | 2 arquivos — start.bat, start.ps1 | aprovado | Resolução dinâmica Ollama via PATH |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -513,7 +514,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 
 - **Última atualização:** 2026-04-25
 - **Último responsável:** Claude Code (Opus 4.5)
-- **Branch ativa:** docs/TASK-T25-setup-guide
+- **Branch ativa:** fix/TASK-T26-hardcoded-paths
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** nenhuma

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -92,6 +92,13 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
 
+### TASK-T26 — Fix Caminhos Hardcoded Ollama ✓
+- **Concluída em:** 2026-04-25
+- **Branch:** fix/TASK-T26-hardcoded-paths
+- **Commit:** 76503b3 fix(scripts): replace hardcoded Ollama paths with dynamic PATH resolution
+- **Detalhes:** `.claude/tasks/TASK-T26.md`
+- **Nota:** Resolução dinâmica via PATH — portabilidade restaurada
+
 ### TASK-T25 — Guia de Setup com Modos Local e Remoto ✓
 - **Concluída em:** 2026-04-25
 - **Branch:** docs/TASK-T25-setup-guide

--- a/.claude/tasks/TASK-T26.md
+++ b/.claude/tasks/TASK-T26.md
@@ -1,5 +1,5 @@
 ### TASK-T26
-- **Status:** pendente
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** patch
 - **Data de criação:** 2026-04-24
@@ -37,11 +37,13 @@ Ambos os scripts assumem que o Ollama está instalado em `C:\Users\lucas\AppData
 | Data | Sessão | Ação Realizada | Status ao Final |
 |------|--------|----------------|-----------------|
 | 2026-04-24 | — | Task criada. Bloqueador de portabilidade identificado | pendente |
+| 2026-04-25 | 1 | Iniciando implementação. Reconhecimento: 5 ocorrências em start.bat, 2 em start.ps1 | em andamento |
+| 2026-04-25 | 1 | Implementação concluída. Todos critérios atendidos | concluída |
 
 #### Resultado (preenchido ao concluir)
-- **Data de conclusão:** [YYYY-MM-DD]
+- **Data de conclusão:** 2026-04-25
 - **Branch:** fix/TASK-T26-hardcoded-paths
-- **Commit(s):** [hash ou mensagem]
-- **Avaliação pós-implementação:** [aprovado / aprovado com ressalvas / reprovado]
-- **Observações:** [notas relevantes]
+- **Commit(s):** 76503b3 fix(scripts): replace hardcoded Ollama paths with dynamic PATH resolution
+- **Avaliação pós-implementação:** aprovado
+- **Observações:** Scripts agora usam `where ollama` (bat) e `Get-Command ollama` (ps1) para resolução dinâmica. Mensagem de erro clara com link para instalação.
 

--- a/start.bat
+++ b/start.bat
@@ -2,8 +2,16 @@
 echo === SmartB100 Startup ===
 echo.
 
-REM Adicionar Ollama ao PATH
-set PATH=%PATH%;C:\Users\lucas\AppData\Local\Programs\Ollama
+REM Localizar Ollama dinamicamente via PATH
+for /f "tokens=*" %%i in ('where ollama 2^>nul') do set OLLAMA_EXE=%%i
+
+if not defined OLLAMA_EXE (
+    echo ERRO: Ollama nao encontrado no PATH do sistema.
+    echo.
+    echo Instale o Ollama em: https://ollama.com
+    echo Apos instalar, reinicie o terminal e execute este script novamente.
+    exit /b 1
+)
 
 echo [1/5] Verificando Qdrant...
 docker-compose up -d
@@ -15,16 +23,16 @@ if %ERRORLEVEL% EQU 0 (
 
 echo.
 echo [2/5] Verificando modelos Ollama...
-"C:\Users\lucas\AppData\Local\Programs\Ollama\ollama.exe" list | findstr "nomic-embed-text" >nul
+"%OLLAMA_EXE%" list | findstr "nomic-embed-text" >nul
 if %ERRORLEVEL% NEQ 0 (
     echo Baixando modelo de embeddings...
-    "C:\Users\lucas\AppData\Local\Programs\Ollama\ollama.exe" pull nomic-embed-text
+    "%OLLAMA_EXE%" pull nomic-embed-text
 )
 
-"C:\Users\lucas\AppData\Local\Programs\Ollama\ollama.exe" list | findstr "llama3.1:8b" >nul
+"%OLLAMA_EXE%" list | findstr "llama3.1:8b" >nul
 if %ERRORLEVEL% NEQ 0 (
     echo Baixando modelo de chat...
-    "C:\Users\lucas\AppData\Local\Programs\Ollama\ollama.exe" pull llama3.1:8b
+    "%OLLAMA_EXE%" pull llama3.1:8b
 )
 echo Ollama: OK
 

--- a/start.ps1
+++ b/start.ps1
@@ -2,8 +2,18 @@
 Write-Host "=== SmartB100 Startup ===" -ForegroundColor Green
 Write-Host ""
 
-# Configurar PATH do Ollama
-$env:PATH += ";C:\Users\lucas\AppData\Local\Programs\Ollama"
+# Localizar Ollama dinamicamente via PATH
+$ollamaCmd = Get-Command ollama -ErrorAction SilentlyContinue
+
+if (-not $ollamaCmd) {
+    Write-Host "ERRO: Ollama nao encontrado no PATH do sistema." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Instale o Ollama em: https://ollama.com" -ForegroundColor Yellow
+    Write-Host "Apos instalar, reinicie o terminal e execute este script novamente."
+    exit 1
+}
+
+$ollamaPath = $ollamaCmd.Source
 
 # 1. Verificar Qdrant
 Write-Host "[1/5] Verificando Qdrant..." -ForegroundColor Yellow
@@ -17,7 +27,6 @@ try {
 # 2. Verificar modelos Ollama
 Write-Host ""
 Write-Host "[2/5] Verificando modelos Ollama..." -ForegroundColor Yellow
-$ollamaPath = "C:\Users\lucas\AppData\Local\Programs\Ollama\ollama.exe"
 
 $models = & $ollamaPath list 2>$null
 if ($models -notmatch "nomic-embed-text") {


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** Scripts `start.bat` e `start.ps1` continham caminhos hardcoded para o Ollama (`C:\Users\lucas\...`), impedindo execução em outras máquinas
- **Task ref.:** TASK-T26

### 2. O que foi feito?
- [x] `start.bat`: substituído caminho hardcoded por `where ollama` para localização dinâmica
- [x] `start.ps1`: substituído caminho hardcoded por `Get-Command ollama` para localização dinâmica
- [x] Adicionada mensagem de erro clara com link https://ollama.com se Ollama não estiver no PATH

### 3. Como testar?
1. Baixe a branch: `git checkout fix/TASK-T26-hardcoded-paths`
2. Verifique que Ollama está no PATH: `where ollama` (cmd) ou `Get-Command ollama` (PowerShell)
3. Execute: `.\start.bat` ou `.\start.ps1`
4. Valide: script inicia normalmente ou exibe mensagem de erro clara se Ollama não instalado

### 4. Evidências
N/A — mudança em scripts de inicialização, não visual.

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada