### PR TITLE
docs(tasks): recover TASK-T18 missing from tasks.md

### DIFF
--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,7 +84,12 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-[nenhuma task ativa no momento]
+### TASK-T18 — Atualizar README.md para MVP
+- **Status:** pendente
+- **Complexidade:** minor
+- **Data de criação:** 2026-04-06
+- **Detalhes:** `.claude/tasks/TASK-T18.md`
+- **Nota:** Task recuperada — estava em `.claude/tasks/` mas ausente desta lista
 
 ---
 

--- a/.claude/tasks/TASK-T18.md
+++ b/.claude/tasks/TASK-T18.md
@@ -1,5 +1,5 @@
 ### TASK-T18
-- **Status:** em andamento
+- **Status:** pendente
 - **Modo:** desenvolvimento
 - **Complexidade:** minor
 - **Data de criação:** 2026-04-06
@@ -38,6 +38,7 @@ O README atual não reflete o estado pós-MVP do projeto. Precisa documentar a n
 | Data | Sessão | Ação Realizada | Status ao Final |
 |------|--------|----------------|-----------------|
 | 2026-04-06 | — | Task criada como parte da FASE 5 do MVP | pendente |
+| 2026-04-25 | — | Task recuperada — ausente de tasks.md, status corrigido | pendente |
 
 #### Resultado (preenchido ao concluir)
 - **Data de conclusão:** [YYYY-MM-DD]


### PR DESCRIPTION
## docs(tasks): recover TASK-T18 missing from tasks.md

### 1. Contexto
- **Motivação:** Durante validação de status das tasks, identificou-se que TASK-T18 existia em `.claude/tasks/TASK-T18.md` mas estava ausente da seção "Tasks Ativas" em `tasks.md`. Inconsistência corrigida.
- **Task ref.:** Correção de integridade do registro de tasks

### 2. O que foi feito?
- [x] TASK-T18 adicionada na seção "Tasks Ativas" de `tasks.md`
- [x] Status corrigido de "em andamento" para "pendente" (não estava sendo trabalhada)
- [x] Log de andamento atualizado com registro da recuperação

### 3. Como testar?
1. Verificar que `tasks.md` lista TASK-T18 em "Tasks Ativas"
2. Verificar que `.claude/tasks/TASK-T18.md` tem status "pendente"

### 4. Evidências
N/A — correção de documentação

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] O código segue o guia de estilo do projeto
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)