### PR TITLE
fix(config): align CHAT_MODEL to llama3.2:3b across all files

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -507,6 +507,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 10 | 2026-04-25 | TASK-T25 | minor | 6 arquivos — SETUP.md, .env.example, core/, retrieval/, database/, tests/ | aprovado | Guia setup local/remoto + suporte QDRANT_API_KEY |
 | 11 | 2026-04-25 | TASK-T26 | patch | 2 arquivos — start.bat, start.ps1 | aprovado | Resolução dinâmica Ollama via PATH |
 | 12 | 2026-04-25 | TASK-T28 | major | 11 arquivos + 2 removidos — codebase completa | aprovado | Remoção completa de React/npm/Node.js; scripts reescritos para Python puro |
+| 13 | 2026-04-25 | TASK-T29 | patch | 2 arquivos — .env.example, docker-compose.yml | aprovado | CHAT_MODEL alinhado para llama3.2:3b |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -520,7 +521,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** TASK-T28 — README sincronizado com estado real da codebase
+- **Última task concluída:** TASK-T29 — CHAT_MODEL alinhado para llama3.2:3b
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,13 +84,53 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-[nenhuma task ativa no momento]
+### TASK-T30 — Alinhar COLLECTION_NAME entre config.py e .env.example
+- **Status:** pendente
+- **Complexidade:** patch
+- **Detalhes:** `.claude/tasks/TASK-T30.md`
+
+### TASK-T31 — Corrigir auth.py para Usar settings.jwt_secret_key
+- **Status:** pendente
+- **Complexidade:** minor
+- **Detalhes:** `.claude/tasks/TASK-T31.md`
+
+### TASK-T32 — Remover Ollama do Docker e Documentar Uso Local Exclusivo
+- **Status:** pendente
+- **Complexidade:** minor
+- **Detalhes:** `.claude/tasks/TASK-T32.md`
+
+### TASK-T33 — Refatorar Caminho do Banco de Dados para Usar Pathlib
+- **Status:** pendente
+- **Complexidade:** minor
+- **Detalhes:** `.claude/tasks/TASK-T33.md`
+
+### TASK-T34 — Substituir datetime.utcnow() por datetime.now(UTC)
+- **Status:** pendente
+- **Complexidade:** patch
+- **Detalhes:** `.claude/tasks/TASK-T34.md`
+
+### TASK-T35 — Corrigir Badge de Coverage no README
+- **Status:** pendente
+- **Complexidade:** patch
+- **Detalhes:** `.claude/tasks/TASK-T35.md`
+
+### TASK-T36 — Remover Módulo Duplicado semantic_entropy
+- **Status:** pendente
+- **Complexidade:** minor
+- **Detalhes:** `.claude/tasks/TASK-T36.md`
 
 ---
 
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T29 — Alinhar CHAT_MODEL em Todos os Arquivos ✓
+- **Concluída em:** 2026-04-25
+- **Branch:** main (pendente de commit)
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** .env.example e docker-compose.yml alinhados para llama3.2:3b
 
 ### TASK-T28 — Remoção completa de referências ao frontend React/npm ✓
 - **Concluída em:** 2026-04-25

--- a/.claude/tasks/TASK-T29.md
+++ b/.claude/tasks/TASK-T29.md
@@ -1,0 +1,63 @@
+# TASK-T29 — Alinhar CHAT_MODEL em Todos os Arquivos
+
+- **Status:** pendente
+- **Modo:** desenvolvimento
+- **Complexidade:** patch
+- **Data de criação:** 2026-04-25
+
+## Objetivo
+
+Sincronizar o valor de `CHAT_MODEL` em todos os arquivos de configuração e documentação para eliminar divergência.
+
+## Contexto
+
+Revisão de codebase identificou que o modelo de chat está definido com valores diferentes em múltiplos locais:
+- `core/config.py` (default): `llama3.2:3b`
+- `.env.example`: `llama3.1:8b`
+- `start.bat` (pull): `llama3.2:3b`
+- `docker-compose.yml` (env): `llama3.1:8b`
+- `README.md`: `llama3.2:3b`
+
+Se o usuário copiar `.env.example` → `.env`, o sistema esperará `llama3.1:8b`, mas `start.bat` baixa apenas `llama3.2:3b`, causando erro de modelo não encontrado.
+
+**Referência:** Relatório de revisão de 2026-04-25 — Inconsistência 1.
+
+## Escopo Técnico
+
+- **Arquivos/módulos envolvidos:**
+  - `.env.example`
+  - `docker-compose.yml`
+- **Dependências necessárias:** nenhuma
+- **Impacto em funcionalidades existentes:** nenhum (apenas alinhamento de configuração)
+
+## Critérios de Aceite
+
+- [ ] Todos os arquivos usam o mesmo modelo default: `llama3.2:3b`
+- [ ] `.env.example` atualizado para `CHAT_MODEL=llama3.2:3b`
+- [ ] `docker-compose.yml` atualizado para `CHAT_MODEL=llama3.2:3b`
+- [ ] Comentário em `.env.example` menciona `llama3.1:8b` como alternativa para mais recursos
+
+## Restrições
+
+- Manter `llama3.2:3b` como default (mais leve, menor barreira de entrada)
+- Não alterar `core/config.py` (já está correto)
+- Não alterar `README.md` (já está correto)
+
+## Referências
+
+- [Ollama Models](https://ollama.com/library)
+- Relatório de revisão em `.claude/instructions.md` Seção 9
+
+## Log de Andamento
+
+| Data | Sessão | Ação Realizada | Status ao Final |
+|------|--------|----------------|-----------------|
+| 2026-04-25 | 1 | Alterado .env.example e docker-compose.yml | concluída |
+
+## Resultado
+
+- **Data de conclusão:** 2026-04-25
+- **Branch:** main (pendente de commit)
+- **Commit(s):** pendente
+- **Avaliação pós-implementação:** aprovado
+- **Observações:** Alinhamento para llama3.2:3b como default em todos os arquivos

--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,8 @@ COLLECTION_NAME=sb100_knowledge
 # MODELOS OLLAMA
 # ============================================================================
 # Modelo de chat (geração de respostas RAG).
-# Opções: llama3.1:8b (recomendado), llama3.2:3b (menos recursos)
-CHAT_MODEL=llama3.1:8b
+# Opções: llama3.2:3b (default, leve), llama3.1:8b (mais recursos/qualidade)
+CHAT_MODEL=llama3.2:3b
 
 # Modelo de embeddings para vetorização e busca semântica.
 # Dimensão: 768 vetores

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "8000:8000"
     environment:
       - QDRANT_URL=http://qdrant:6333
-      - CHAT_MODEL=llama3.1:8b
+      - CHAT_MODEL=llama3.2:3b
       - EMBED_MODEL=nomic-embed-text
       - OLLAMA_HOST=http://ollama:11434
     volumes:


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** Inconsistência entre arquivos de configuração causava erro de modelo não encontrado em novas máquinas
- **Link da Tarefa:** N/A
- **Task ref.:** TASK-T29

### 2. O que foi feito?
- [x] Atualizado `.env.example` de `llama3.1:8b` para `llama3.2:3b`
- [x] Atualizado `docker-compose.yml` de `llama3.1:8b` para `llama3.2:3b`
- [x] Comentário em `.env.example` ajustado para refletir nova ordenação

### 3. Como testar?
1. Baixe a branch: `git checkout fix/TASK-T29-align-chat-model`
2. Verifique que `.env.example` contém `CHAT_MODEL=llama3.2:3b`
3. Verifique que `docker-compose.yml` contém `CHAT_MODEL=llama3.2:3b`
4. Confirme alinhamento com `core/config.py` (default: `llama3.2:3b`)

### 4. Evidências
N/A (apenas configuração)

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada