### PR TITLE
fix(auth): use settings.jwt_secret_key instead of os.environ.get

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -507,6 +507,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 10 | 2026-04-25 | TASK-T25 | minor | 6 arquivos — SETUP.md, .env.example, core/, retrieval/, database/, tests/ | aprovado | Guia setup local/remoto + suporte QDRANT_API_KEY |
 | 11 | 2026-04-25 | TASK-T26 | patch | 2 arquivos — start.bat, start.ps1 | aprovado | Resolução dinâmica Ollama via PATH |
 | 12 | 2026-04-25 | TASK-T28 | major | 11 arquivos + 2 removidos — codebase completa | aprovado | Remoção completa de React/npm/Node.js; scripts reescritos para Python puro |
+| 13 | 2026-04-25 | TASK-T31 | minor | 1 arquivo — api/routes/auth.py | aprovado | JWT_SECRET_KEY via settings + validação de erro |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -516,11 +517,11 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 
 - **Última atualização:** 2026-04-25
 - **Último responsável:** Claude Code (Opus 4.5)
-- **Branch ativa:** dev (TASK-T28 pendente de commit)
+- **Branch ativa:** fix/TASK-T31-jwt-secret-settings
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** TASK-T28 — README sincronizado com estado real da codebase
+- **Última task concluída:** TASK-T31 — auth.py usa settings.jwt_secret_key com validação
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -92,6 +92,13 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
 
+### TASK-T31 — Corrigir auth.py para Usar settings.jwt_secret_key ✓
+- **Concluída em:** 2026-04-25
+- **Branch:** fix/TASK-T31-jwt-secret-settings
+- **Commit:** a66cc61
+- **Avaliação:** aprovado
+- **Nota:** Substituído os.environ.get() por settings.jwt_secret_key com validação de erro claro
+
 ### TASK-T28 — Remoção completa de referências ao frontend React/npm ✓
 - **Concluída em:** 2026-04-25
 - **Branch:** docs/TASK-T28-readme-sync

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -11,7 +11,6 @@ Segurança:
 """
 
 import hashlib
-import os
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -21,10 +20,14 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from core.config import settings
 from database.db import get_db
 from database.models import User
 
-SECRET_KEY = os.environ.get("JWT_SECRET_KEY", "super-secret-key-replace-in-production")
+if not settings.jwt_secret_key:
+    raise ValueError("JWT_SECRET_KEY must be configured in .env or environment variables")
+
+SECRET_KEY = settings.jwt_secret_key
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 dias
 


### PR DESCRIPTION
## Contexto
- **Motivação:** `auth.py` usava `os.environ.get("JWT_SECRET_KEY")` que só lê variáveis do sistema operacional, ignorando o arquivo `.env`. Com essa correção, o valor é lido via Pydantic Settings (`core/config.py`) que carrega o `.env` automaticamente.
- **Task ref.:** TASK-T31

## O que foi feito?
- [x] Removido `import os` (não mais necessário)
- [x] Adicionado `from core.config import settings`
- [x] `SECRET_KEY` agora usa `settings.jwt_secret_key`
- [x] Validação explícita: se `jwt_secret_key` vazio, levanta `ValueError` com mensagem clara

## Como testar?
1. Baixe a branch: `git checkout fix/TASK-T31-jwt-secret-settings`
2. Certifique-se de que `JWT_SECRET_KEY` **não** está exportado no ambiente do sistema
3. Configure `JWT_SECRET_KEY=minha-chave` no `.env`
4. Rode a API: `python -m uvicorn api.main:app --reload`
5. Verifique: A API deve iniciar sem erro (antes falharia silenciosamente usando fallback inseguro)

## Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada

## Observação Importante

⚠️ **Sincronização pendente:** A pasta `.claude/tasks/` contendo os arquivos individuais de cada task (TASK-T30.md, TASK-T31.md, etc.) existe apenas na branch `fix/TASK-T30-align-collection-name`. Essa pasta deveria ser mergeada para `main` para manter o histórico e referência das tasks. Recomenda-se mergear a PR da TASK-T30 primeiro ou sincronizar essa estrutura.

---

🤖 Generated with [Claude Code](https://claude.ai/code)