### PR TITLE
chore(docker): remove Ollama from Docker and document local-only usage

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -510,6 +510,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 13 | 2026-04-25 | TASK-T29 | patch | 2 arquivos — .env.example, docker-compose.yml | aprovado | CHAT_MODEL alinhado para llama3.2:3b |
 | 14 | 2026-04-25 | TASK-T30 | patch | 1 arquivo — .env.example | aprovado | COLLECTION_NAME alinhado para archives_v2 |
 | 15 | 2026-04-25 | TASK-T31 | minor | 1 arquivo — api/routes/auth.py | aprovado | JWT_SECRET_KEY via settings + validação de erro |
+| 16 | 2026-04-25 | TASK-T32 | minor | 3 arquivos — docker-compose.yml, README.md, SETUP.md | aprovado | Ollama removido do Docker, uso local exclusivo documentado |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -519,11 +520,11 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 
 - **Última atualização:** 2026-04-25
 - **Último responsável:** Claude Code (Opus 4.5)
-- **Branch ativa:** fix/TASK-T31-jwt-secret-settings
+- **Branch ativa:** chore/TASK-T32-remove-ollama-docker
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** TASK-T31 — auth.py usa settings.jwt_secret_key com validação
+- **Última task concluída:** TASK-T32 — Ollama removido do Docker, documentação atualizada para uso local exclusivo
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,11 +84,6 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T32 — Remover Ollama do Docker e Documentar Uso Local Exclusivo
-- **Status:** pendente
-- **Complexidade:** minor
-- **Detalhes:** `.claude/tasks/TASK-T32.md`
-
 ### TASK-T33 — Refatorar Caminho do Banco de Dados para Usar Pathlib
 - **Status:** pendente
 - **Complexidade:** minor
@@ -115,6 +110,13 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
 
+### TASK-T32 — Remover Ollama do Docker e Documentar Uso Local Exclusivo ✓
+- **Concluída em:** 2026-04-25
+- **Branch:** chore/TASK-T32-remove-ollama-docker
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** Servico Ollama removido do docker-compose. OLLAMA_HOST usa host.docker.internal. SETUP.md alinhado com T29/T30.
+
 ### TASK-T31 — Corrigir auth.py para Usar settings.jwt_secret_key ✓
 - **Concluída em:** 2026-04-25
 - **Branch:** fix/TASK-T31-jwt-secret-settings
@@ -125,7 +127,8 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 ### TASK-T30 — Alinhar COLLECTION_NAME entre config.py e .env.example ✓
 - **Concluída em:** 2026-04-25
 - **Branch:** fix/TASK-T30-align-collection-name
-- **Commit:** pendente
+- **Commit:** d303653
+- **PR:** [#30](https://github.com/LukeSantossz/sb100_agents/pull/30)
 - **Avaliação:** aprovado
 - **Nota:** .env.example alinhado para archives_v2
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -113,7 +113,7 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 ### TASK-T32 — Remover Ollama do Docker e Documentar Uso Local Exclusivo ✓
 - **Concluída em:** 2026-04-25
 - **Branch:** chore/TASK-T32-remove-ollama-docker
-- **Commit:** pendente
+- **Commit:** bfb476d
 - **Avaliação:** aprovado
 - **Nota:** Servico Ollama removido do docker-compose. OLLAMA_HOST usa host.docker.internal. SETUP.md alinhado com T29/T30.
 

--- a/.claude/tasks/TASK-T29.md
+++ b/.claude/tasks/TASK-T29.md
@@ -1,6 +1,6 @@
 # TASK-T29 — Alinhar CHAT_MODEL em Todos os Arquivos
 
-- **Status:** pendente
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** patch
 - **Data de criação:** 2026-04-25
@@ -57,7 +57,8 @@ Se o usuário copiar `.env.example` → `.env`, o sistema esperará `llama3.1:8b
 ## Resultado
 
 - **Data de conclusão:** 2026-04-25
-- **Branch:** main (pendente de commit)
-- **Commit(s):** pendente
+- **Branch:** fix/TASK-T29-align-chat-model
+- **Commit(s):** bef939a
+- **PR:** [#29](https://github.com/LukeSantossz/sb100_agents/pull/29)
 - **Avaliação pós-implementação:** aprovado
 - **Observações:** Alinhamento para llama3.2:3b como default em todos os arquivos

--- a/.claude/tasks/TASK-T30.md
+++ b/.claude/tasks/TASK-T30.md
@@ -1,6 +1,6 @@
 # TASK-T30 — Alinhar COLLECTION_NAME entre config.py e .env.example
 
-- **Status:** pendente
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** patch
 - **Data de criação:** 2026-04-25
@@ -51,6 +51,7 @@ Se o usuário indexar PDFs sem `.env`, a coleção será `archives_v2`. Se depoi
 
 - **Data de conclusão:** 2026-04-25
 - **Branch:** fix/TASK-T30-align-collection-name
-- **Commit(s):** pendente
+- **Commit(s):** d303653
+- **PR:** [#30](https://github.com/LukeSantossz/sb100_agents/pull/30)
 - **Avaliação pós-implementação:** aprovado
 - **Observações:** Alinhamento com default de core/config.py

--- a/.claude/tasks/TASK-T31.md
+++ b/.claude/tasks/TASK-T31.md
@@ -1,6 +1,6 @@
 # TASK-T31 — Corrigir auth.py para Usar settings.jwt_secret_key
 
-- **Status:** pendente
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** minor
 - **Data de criação:** 2026-04-25
@@ -51,12 +51,13 @@ O problema é que `os.environ.get()` só lê variáveis de ambiente do **sistema
 
 | Data | Sessão | Ação Realizada | Status ao Final |
 |------|--------|----------------|-----------------|
-| —    | —      | —              | —               |
+| 2026-04-25 | 1 | Substituído os.environ.get() por settings.jwt_secret_key com validação | concluída |
 
 ## Resultado
 
-- **Data de conclusão:** —
-- **Branch:** —
-- **Commit(s):** —
-- **Avaliação pós-implementação:** —
-- **Observações:** —
+- **Data de conclusão:** 2026-04-25
+- **Branch:** fix/TASK-T31-jwt-secret-settings
+- **Commit(s):** 2e1aafa
+- **PR:** [#31](https://github.com/LukeSantossz/sb100_agents/pull/31)
+- **Avaliação pós-implementação:** aprovado
+- **Observações:** Substituído os.environ.get() por settings.jwt_secret_key com validação de erro claro

--- a/.claude/tasks/TASK-T32.md
+++ b/.claude/tasks/TASK-T32.md
@@ -1,6 +1,6 @@
 # TASK-T32 — Remover Ollama do Docker e Documentar Uso Local Exclusivo
 
-- **Status:** pendente
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** minor
 - **Data de criação:** 2026-04-25
@@ -54,12 +54,12 @@ A presença do Ollama no docker-compose causa confusão e potencial conflito de 
 
 | Data | Sessão | Ação Realizada | Status ao Final |
 |------|--------|----------------|-----------------|
-| —    | —      | —              | —               |
+| 2026-04-25 | 1 | Removido servico Ollama do docker-compose, atualizado README e SETUP | concluída |
 
 ## Resultado
 
-- **Data de conclusão:** —
-- **Branch:** —
-- **Commit(s):** —
-- **Avaliação pós-implementação:** —
-- **Observações:** —
+- **Data de conclusão:** 2026-04-25
+- **Branch:** chore/TASK-T32-remove-ollama-docker
+- **Commit(s):** pendente (aguardando commit)
+- **Avaliação pós-implementação:** aprovado
+- **Observações:** OLLAMA_HOST atualizado para host.docker.internal. SETUP.md corrigido para alinhar com T29/T30.

--- a/.claude/tasks/TASK-T32.md
+++ b/.claude/tasks/TASK-T32.md
@@ -60,6 +60,6 @@ A presença do Ollama no docker-compose causa confusão e potencial conflito de 
 
 - **Data de conclusão:** 2026-04-25
 - **Branch:** chore/TASK-T32-remove-ollama-docker
-- **Commit(s):** pendente (aguardando commit)
+- **Commit(s):** bfb476d
 - **Avaliação pós-implementação:** aprovado
 - **Observações:** OLLAMA_HOST atualizado para host.docker.internal. SETUP.md corrigido para alinhar com T29/T30.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ For architecture details and design decisions, see [`ARCHITECTURE.md`](./ARCHITE
 
 ### Prerequisites
 
-- **Docker Desktop** (for Qdrant)
-- **Ollama** (for local LLM inference)
+- **Docker Desktop** (for Qdrant vector database only)
+- **Ollama** installed locally (for LLM inference and embeddings — not via Docker)
 - **Python 3.12+**
 
 ### Installation
@@ -64,7 +64,7 @@ powershell -ExecutionPolicy Bypass -File .\start.ps1
 
 **Manual (step by step):**
 ```bash
-# 1. Start infrastructure (Qdrant + Ollama via Docker)
+# 1. Start infrastructure (Qdrant via Docker — Ollama runs locally)
 docker compose --profile infra up -d
 
 # 2. Index PDF documents (first run only)
@@ -152,7 +152,7 @@ sb100_agents/
 ├── .github/workflows/ci.yml        # GitHub Actions CI pipeline
 ├── ARCHITECTURE.md
 ├── SETUP.md                        # Detailed setup guide (local/remote Qdrant)
-├── docker-compose.yml              # Docker services with profiles (infra/app)
+├── docker-compose.yml              # Docker services (infra: Qdrant / app: API+Gradio)
 ├── pyproject.toml
 ├── start.bat                       # Windows startup script
 └── start.ps1                       # PowerShell startup script

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,19 +33,19 @@ O sistema suporta dois modos de operação do Qdrant:
 
 ---
 
-## 2. Modelos Ollama
+## 2. Modelos Ollama (local)
 
-Execute os comandos abaixo para baixar os modelos necessários:
+Ollama deve ser instalado e executado **localmente** (não via Docker). Execute os comandos abaixo para baixar os modelos necessários:
 
 ```bash
 # Modelo de chat (geração de respostas)
-ollama pull llama3.1:8b
+ollama pull llama3.2:3b
 
 # Modelo de embeddings (vetorização)
 ollama pull nomic-embed-text
 ```
 
-> **Nota**: O modelo `llama3.1:8b` requer ~5GB de VRAM. Para máquinas com menos recursos, use `llama3.2:3b` (ajuste no `.env`).
+> **Nota**: O modelo default é `llama3.2:3b` (mais leve). Para máquinas com mais recursos, use `llama3.1:8b` (ajuste `CHAT_MODEL` no `.env`).
 
 ---
 
@@ -79,10 +79,10 @@ Edite o `.env` com as seguintes variáveis:
 ```env
 # === Modo Local (Qdrant via Docker) ===
 QDRANT_URL=http://localhost:6333
-COLLECTION_NAME=sb100_knowledge
+COLLECTION_NAME=archives_v2
 
-# Modelos Ollama
-CHAT_MODEL=llama3.1:8b
+# Modelos Ollama (roda localmente, não via Docker)
+CHAT_MODEL=llama3.2:3b
 EMBED_MODEL=nomic-embed-text
 
 # Configurações de busca
@@ -106,10 +106,10 @@ Para usar o servidor Qdrant remoto compartilhado:
 # === Modo Remoto (Qdrant via ZeroTier) ===
 QDRANT_URL=http://<REMOTE_HOST_ZEROTIER>:6333
 QDRANT_API_KEY=<SOLICITAR_AO_TECH_LEAD>
-COLLECTION_NAME=sb100_knowledge
+COLLECTION_NAME=archives_v2
 
-# Modelos Ollama (local)
-CHAT_MODEL=llama3.1:8b
+# Modelos Ollama (roda localmente, não via Docker)
+CHAT_MODEL=llama3.2:3b
 EMBED_MODEL=nomic-embed-text
 
 # Configurações de busca
@@ -130,12 +130,15 @@ JWT_SECRET_KEY=super-secret-key-replace-in-production
 ### 5.1 Modo Local
 
 ```bash
-# Iniciar Qdrant via Docker Compose
+# Iniciar Qdrant via Docker Compose (apenas Qdrant — Ollama roda localmente)
 docker compose --profile infra up -d
 
 # Verificar se Qdrant está rodando
 curl http://localhost:6333/health
 # Resposta esperada: {"title":"qdrant - vector search engine","version":"..."}
+
+# Verificar se Ollama está rodando localmente
+ollama list
 ```
 
 ### 5.2 Modo Remoto
@@ -304,12 +307,12 @@ docker compose --profile infra up -d
 ### Modelo não encontrado
 
 ```
-ollama._exceptions.ResponseError: model 'llama3.1:8b' not found
+ollama._exceptions.ResponseError: model 'llama3.2:3b' not found
 ```
 
 **Solução**: Baixe o modelo:
 ```bash
-ollama pull llama3.1:8b
+ollama pull llama3.2:3b
 ```
 
 ### ZeroTier não conecta
@@ -338,7 +341,7 @@ zerotier-cli join <NETWORK_ID>
 
 ```bash
 # 1. Modelos
-ollama pull llama3.1:8b && ollama pull nomic-embed-text
+ollama pull llama3.2:3b && ollama pull nomic-embed-text
 
 # 2. Dependências
 uv sync
@@ -360,7 +363,7 @@ uvicorn api.main:app --reload
 
 ```bash
 # 1. Modelos
-ollama pull llama3.1:8b && ollama pull nomic-embed-text
+ollama pull llama3.2:3b && ollama pull nomic-embed-text
 
 # 2. Dependências
 uv sync

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   # ============================================================================
-  # Profile: infra - Serviços de infraestrutura (Qdrant + Ollama)
+  # Profile: infra - Serviços de infraestrutura (Qdrant)
   # Uso: docker compose --profile infra up -d
+  # Nota: Ollama roda localmente (não via Docker). Veja README.md / SETUP.md.
   # ============================================================================
 
   qdrant:
@@ -13,18 +14,6 @@ services:
       - "6334:6334"
     volumes:
       - ./qdrant_storage:/qdrant/storage
-    restart: unless-stopped
-    networks:
-      - smartb100_net
-
-  ollama:
-    image: ollama/ollama:latest
-    container_name: smartb100_ollama
-    profiles: ["infra"]
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama_data:/root/.ollama
     restart: unless-stopped
     networks:
       - smartb100_net
@@ -46,13 +35,12 @@ services:
       - QDRANT_URL=http://qdrant:6333
       - CHAT_MODEL=llama3.2:3b
       - EMBED_MODEL=nomic-embed-text
-      - OLLAMA_HOST=http://ollama:11434
+      - OLLAMA_HOST=http://host.docker.internal:11434
     volumes:
       - ./smartb100_v2.db:/app/smartb100_v2.db
     restart: unless-stopped
     depends_on:
       - qdrant
-      - ollama
     networks:
       - smartb100_net
 
@@ -76,6 +64,3 @@ services:
 networks:
   smartb100_net:
     driver: bridge
-
-volumes:
-  ollama_data:


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** O `docker-compose.yml` definia um serviço Ollama no profile `infra`, mas todos os scripts (`start.bat`, `start.ps1`) e a documentação (`README.md`) assumem Ollama instalado localmente. A presença do Ollama no Docker causava ambiguidade e potencial conflito de porta (11434).
- **Task ref.:** TASK-T32

### 2. O que foi feito?
- [x] Serviço `ollama` removido do `docker-compose.yml`
- [x] Volume `ollama_data` removido do `docker-compose.yml`
- [x] Dependência `ollama` removida do serviço `api`
- [x] `OLLAMA_HOST` atualizado para `http://host.docker.internal:11434` (acesso ao Ollama local a partir do container)
- [x] Comentário do profile `infra` atualizado (apenas Qdrant)
- [x] `README.md` — Prerequisites e instruções de startup atualizados para enfatizar Ollama local
- [x] `SETUP.md` — Documentação completa atualizada: Ollama local exclusivo, modelo default `llama3.2:3b`, collection `archives_v2`

### 3. Como testar?
1. Baixe a branch: `git checkout chore/TASK-T32-remove-ollama-docker`
2. Valide o docker-compose: `docker compose config --quiet`
3. Rode os testes: `pytest tests/ -v --ignore=tests/test_integration.py -o "addopts="`
4. Verifique: nenhuma referência a Ollama Docker na documentação (`README.md`, `SETUP.md`)
5. Verifique: `docker compose --profile infra up -d` sobe apenas Qdrant

### 4. Evidências
Mudança de configuração/documentação — sem evidências visuais.

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada