### PR TITLE
refactor(database): replace os.path with pathlib.Path for DB_PATH

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -510,6 +510,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 13 | 2026-04-25 | TASK-T29 | patch | 2 arquivos — .env.example, docker-compose.yml | aprovado | CHAT_MODEL alinhado para llama3.2:3b |
 | 14 | 2026-04-25 | TASK-T30 | patch | 1 arquivo — .env.example | aprovado | COLLECTION_NAME alinhado para archives_v2 |
 | 15 | 2026-04-25 | TASK-T31 | minor | 1 arquivo — api/routes/auth.py | aprovado | JWT_SECRET_KEY via settings + validação de erro |
+| 16 | 2026-04-25 | TASK-T33 | minor | 1 arquivo — database/db.py | aprovado | os.path substituído por pathlib.Path |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -518,12 +519,12 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
 - **Última atualização:** 2026-04-25
-- **Último responsável:** Claude Code (Opus 4.5)
-- **Branch ativa:** fix/TASK-T31-jwt-secret-settings
+- **Último responsável:** Claude Code (Opus 4)
+- **Branch ativa:** refactor/TASK-T33-pathlib-db-path
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** TASK-T31 — auth.py usa settings.jwt_secret_key com validação
+- **Última task concluída:** TASK-T33 — database/db.py refatorado para usar pathlib.Path
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -89,11 +89,6 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 - **Complexidade:** minor
 - **Detalhes:** `.claude/tasks/TASK-T32.md`
 
-### TASK-T33 — Refatorar Caminho do Banco de Dados para Usar Pathlib
-- **Status:** concluída
-- **Complexidade:** minor
-- **Detalhes:** `.claude/tasks/TASK-T33.md`
-
 ### TASK-T34 — Substituir datetime.utcnow() por datetime.now(UTC)
 - **Status:** pendente
 - **Complexidade:** patch
@@ -114,6 +109,13 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T33 — Refatorar Caminho do Banco de Dados para Usar Pathlib ✓
+- **Concluída em:** 2026-04-25
+- **Branch:** refactor/TASK-T33-pathlib-db-path
+- **Commit:** e839a86
+- **Avaliação:** aprovado
+- **Nota:** os.path substituído por pathlib.Path em database/db.py. API pública inalterada.
 
 ### TASK-T31 — Corrigir auth.py para Usar settings.jwt_secret_key ✓
 - **Concluída em:** 2026-04-25

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -90,7 +90,7 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 - **Detalhes:** `.claude/tasks/TASK-T32.md`
 
 ### TASK-T33 — Refatorar Caminho do Banco de Dados para Usar Pathlib
-- **Status:** pendente
+- **Status:** concluída
 - **Complexidade:** minor
 - **Detalhes:** `.claude/tasks/TASK-T33.md`
 

--- a/.claude/tasks/TASK-T33.md
+++ b/.claude/tasks/TASK-T33.md
@@ -57,6 +57,6 @@ Isso navega 3 níveis acima de `database/db.py` para encontrar a raiz. Se a estr
 
 - **Data de conclusão:** 2026-04-25
 - **Branch:** refactor/TASK-T33-pathlib-db-path
-- **Commit(s):** pendente (aguardando commit)
+- **Commit(s):** e839a86
 - **Avaliação pós-implementação:** aprovado
 - **Observações:** Substituição direta os.path -> pathlib.Path. Import `os` removido (era uso único). API pública inalterada.

--- a/.claude/tasks/TASK-T33.md
+++ b/.claude/tasks/TASK-T33.md
@@ -1,6 +1,6 @@
 # TASK-T33 — Refatorar Caminho do Banco de Dados para Usar Pathlib
 
-- **Status:** pendente
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** minor
 - **Data de criação:** 2026-04-25
@@ -32,10 +32,10 @@ Isso navega 3 níveis acima de `database/db.py` para encontrar a raiz. Se a estr
 
 ## Critérios de Aceite
 
-- [ ] `database/db.py` usa `pathlib.Path` em vez de `os.path`
-- [ ] Caminho calculado como `Path(__file__).resolve().parents[2] / "smartb100_v2.db"`
-- [ ] Testes existentes continuam passando
-- [ ] Banco de dados criado no mesmo local de antes
+- [x] `database/db.py` usa `pathlib.Path` em vez de `os.path`
+- [x] Caminho calculado como `Path(__file__).resolve().parents[2] / "smartb100_v2.db"`
+- [x] Testes existentes continuam passando (18/18)
+- [x] Banco de dados criado no mesmo local de antes
 
 ## Restrições
 
@@ -51,12 +51,12 @@ Isso navega 3 níveis acima de `database/db.py` para encontrar a raiz. Se a estr
 
 | Data | Sessão | Ação Realizada | Status ao Final |
 |------|--------|----------------|-----------------|
-| —    | —      | —              | —               |
+| 2026-04-25 | 1 | Reconhecimento, implementação pathlib, testes 18/18, lint OK | concluída |
 
 ## Resultado
 
-- **Data de conclusão:** —
-- **Branch:** —
-- **Commit(s):** —
-- **Avaliação pós-implementação:** —
-- **Observações:** —
+- **Data de conclusão:** 2026-04-25
+- **Branch:** refactor/TASK-T33-pathlib-db-path
+- **Commit(s):** pendente (aguardando commit)
+- **Avaliação pós-implementação:** aprovado
+- **Observações:** Substituição direta os.path -> pathlib.Path. Import `os` removido (era uso único). API pública inalterada.

--- a/database/db.py
+++ b/database/db.py
@@ -1,13 +1,11 @@
-import os
 from collections.abc import Generator
+from pathlib import Path
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 # SQLite database file relative to the project root
-DB_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "smartb100_v2.db"
-)
+DB_PATH = str(Path(__file__).resolve().parents[2] / "smartb100_v2.db")
 
 SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
 


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** `database/db.py` usava navegação relativa frágil com `os.path.dirname()` encadeado 3 vezes para encontrar a raiz do projeto. Se a estrutura de pastas mudar ou o arquivo for movido, o caminho quebra silenciosamente.
- **Task ref.:** TASK-T33

### 2. O que foi feito?
- [x] Substituído `os.path.join(os.path.dirname(...))` por `Path(__file__).resolve().parents[2] / "smartb100_v2.db"`
- [x] Removido import `os` (era uso único)
- [x] Caminho final resolve para o mesmo local de antes

### 3. Como testar?
1. Baixe a branch: `git checkout refactor/TASK-T33-pathlib-db-path`
2. Verifique o caminho: `python -c "from database.db import DB_PATH; print(DB_PATH)"`
3. Rode os testes: `pytest tests/ -v --ignore=tests/test_integration.py -o "addopts="`
4. Valide que 18/18 testes passam e o DB_PATH aponta para `smartb100_v2.db` na raiz do projeto

### 4. Evidências
Mudança apenas em backend — sem componente visual.

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada