### PR TITLE
fix(api,database,scripts): corrige bloqueio do event loop, DB_PATH e arquivo nul

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -519,6 +519,8 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 22 | 2026-04-26 | TASK-T38 | patch | 2 arquivos — archives/smart_boletim.pdf, .gitignore | aprovado | PDF versionado em archives/; entradas removidas do .gitignore |
 | 23 | 2026-04-26 | TASK-T39 | minor | 1 arquivo — README.md | aprovado | Getting Started com 7 passos, .env explícito, verificação por etapa |
 | 24 | 2026-04-27 | TASK-T40 | minor | 1 arquivo — api/routes/chat.py | aprovado | async def → def; event loop desbloqueado |
+| 25 | 2026-04-27 | TASK-T41 | patch | 1 arquivo — database/db.py | aprovado | parents[2] ��� parents[1]; DB na raiz do projeto |
+| 26 | 2026-04-27 | TASK-T42 | patch | 1 arquivo — start.bat | aprovado | >nul → >NUL; evita criação de arquivo literal |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -532,7 +534,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** mudanças pré-existentes em README.md (não commitadas, fora de escopo)
-- **Última task concluída:** TASK-T40 — async def → def no endpoint /chat
+- **Última task concluída:** TASK-T42 — >nul → >NUL no start.bat
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -518,6 +518,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 21 | 2026-04-26 | TASK-T37 | patch | 1 arquivo — database/semantic_chunker.py | aprovado | Emojis Unicode removidos dos prints; prefixos ASCII ([OK], [INFO]) |
 | 22 | 2026-04-26 | TASK-T38 | patch | 2 arquivos — archives/smart_boletim.pdf, .gitignore | aprovado | PDF versionado em archives/; entradas removidas do .gitignore |
 | 23 | 2026-04-26 | TASK-T39 | minor | 1 arquivo — README.md | aprovado | Getting Started com 7 passos, .env explícito, verificação por etapa |
+| 24 | 2026-04-27 | TASK-T40 | minor | 1 arquivo — api/routes/chat.py | aprovado | async def → def; event loop desbloqueado |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -525,13 +526,13 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
-- **Última atualização:** 2026-04-26
+- **Última atualização:** 2026-04-27
 - **Último responsável:** Claude Code (Opus 4)
-- **Branch ativa:** main
+- **Branch ativa:** fix/TASK-T40-async-blocking-eventloop
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
-- **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** TASK-T39 — README reescrito com setup passo a passo
+- **Divergências externas pendentes:** mudanças pré-existentes em README.md (não commitadas, fora de escopo)
+- **Última task concluída:** TASK-T40 — async def → def no endpoint /chat
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,57 +84,27 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T41
-- **Status:** pendente
-- **Modo:** desenvolvimento
-- **Complexidade:** patch
-- **Data de criação:** 2026-04-27
-
-#### Objetivo (!obrigatório)
-Corrigir `DB_PATH` em `database/db.py` que cria `smartb100_v2.db` no Desktop em vez da raiz do projeto.
-
-#### Contexto (!obrigatório)
-`Path(__file__).resolve().parents[2]` sobe dois níveis a partir de `database/db.py`, resultando no diretório pai do projeto (Desktop). O correto é `.parents[1]` para chegar à raiz do projeto.
-
-#### Escopo Técnico (!obrigatório)
-- **Arquivos/módulos envolvidos:** `database/db.py`
-- **Dependências necessárias:** nenhuma
-- **Impacto em funcionalidades existentes:** altera local do banco SQLite; dados existentes no Desktop não serão migrados automaticamente
-
-#### Critérios de Aceite (!obrigatório)
-- [ ] `smartb100_v2.db` é criado na raiz do projeto (`sb100_agents/`)
-- [ ] Testes existentes continuam passando
-- [ ] Ruff lint passa sem erros
-
----
-
-### TASK-T42
-- **Status:** pendente
-- **Modo:** desenvolvimento
-- **Complexidade:** patch
-- **Data de criação:** 2026-04-27
-
-#### Objetivo (!obrigatório)
-Corrigir `start.bat` que cria arquivo `nul` na raiz do projeto em vez de redirecionar para o dispositivo nulo do Windows.
-
-#### Contexto (!obrigatório)
-Redirecionamentos `>nul` no `start.bat` são interpretados como nome de arquivo literal em certos contextos do Windows (OneDrive, PowerShell, encoding). Deve-se usar `> NUL` para garantir interpretação correta.
-
-#### Escopo Técnico (!obrigatório)
-- **Arquivos/módulos envolvidos:** `start.bat`
-- **Dependências necessárias:** nenhuma
-- **Impacto em funcionalidades existentes:** nenhum
-
-#### Critérios de Aceite (!obrigatório)
-- [ ] Arquivo `nul` não é criado ao executar `start.bat`
-- [ ] Redirecionamentos usam formato robusto para Windows
-- [ ] Script continua funcional
+[nenhuma task ativa]
 
 ---
 
 ## Tasks Concluídas
 
-> Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
+> Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico �� cumulativo.
+
+### TASK-T42 — Corrigir redirecionamento >nul no start.bat ✓
+- **Concluída em:** 2026-04-27
+- **Branch:** fix/TASK-T40-async-blocking-eventloop
+- **Commit:** 522b6d4
+- **Avaliação:** aprovado
+- **Nota:** 5 ocorrências de `>nul` substituídas por `>NUL` (uppercase) para evitar criação de arquivo literal.
+
+### TASK-T41 — Corrigir DB_PATH em database/db.py ✓
+- **Concluída em:** 2026-04-27
+- **Branch:** fix/TASK-T40-async-blocking-eventloop
+- **Commit:** e50f78f
+- **Avaliação:** aprovado
+- **Nota:** `.parents[2]` corrigido para `.parents[1]`. Banco agora é criado na raiz do projeto.
 
 ### TASK-T40 — Corrigir async def bloqueante no endpoint /chat ✓
 - **Concluída em:** 2026-04-27

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,41 +84,6 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T40
-- **Status:** em andamento
-- **Modo:** desenvolvimento
-- **Complexidade:** minor
-- **Data de criação:** 2026-04-27
-
-#### Objetivo (!obrigatório)
-Corrigir endpoint `/chat` que bloqueia o event loop do FastAPI por usar chamadas síncronas dentro de `async def`.
-
-#### Contexto (!obrigatório)
-O endpoint `chat` em `api/routes/chat.py` é declarado como `async def` mas chama funções síncronas bloqueantes (Ollama, Qdrant). Isso congela o event loop do uvicorn, impedindo que qualquer outra requisição seja processada enquanto o LLM gera a resposta. O Gradio reporta "Não foi possível conectar à API" porque o timeout é atingido.
-
-#### Escopo Técnico (!obrigatório)
-- **Arquivos/módulos envolvidos:** `api/routes/chat.py`
-- **Dependências necessárias:** nenhuma
-- **Impacto em funcionalidades existentes:** melhora disponibilidade; comportamento funcional inalterado
-
-#### Critérios de Aceite (!obrigatório)
-- [ ] Endpoint `chat` não bloqueia o event loop do FastAPI
-- [ ] `/health` responde enquanto `/chat` está processando
-- [ ] Testes existentes continuam passando
-- [ ] Ruff lint passa sem erros
-
-#### Restrições
-- Mudança mínima: alterar `async def` para `def` (FastAPI roda em thread pool automaticamente)
-- Não alterar lógica de negócio do pipeline RAG
-
-#### Log de Andamento (atualizado pelo agente)
-
-| Data | Sessão | Ação Realizada | Status ao Final |
-|------|--------|----------------|-----------------|
-| 2026-04-27 | 1 | Diagnóstico: async def com chamadas síncronas bloqueia event loop | em andamento |
-
----
-
 ### TASK-T41
 - **Status:** pendente
 - **Modo:** desenvolvimento
@@ -170,6 +135,13 @@ Redirecionamentos `>nul` no `start.bat` são interpretados como nome de arquivo 
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T40 — Corrigir async def bloqueante no endpoint /chat ✓
+- **Concluída em:** 2026-04-27
+- **Branch:** fix/TASK-T40-async-blocking-eventloop
+- **Commit:** 0b299c7
+- **Avaliação:** aprovado
+- **Nota:** `async def chat()` alterado para `def chat()`. FastAPI executa handlers síncronos em thread pool, liberando o event loop para /health e outras requisições.
 
 ### TASK-T39 — Atualizar README com Setup Passo a Passo ✓
 - **Concluída em:** 2026-04-26

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,7 +84,86 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-[nenhuma task ativa]
+### TASK-T40
+- **Status:** em andamento
+- **Modo:** desenvolvimento
+- **Complexidade:** minor
+- **Data de criação:** 2026-04-27
+
+#### Objetivo (!obrigatório)
+Corrigir endpoint `/chat` que bloqueia o event loop do FastAPI por usar chamadas síncronas dentro de `async def`.
+
+#### Contexto (!obrigatório)
+O endpoint `chat` em `api/routes/chat.py` é declarado como `async def` mas chama funções síncronas bloqueantes (Ollama, Qdrant). Isso congela o event loop do uvicorn, impedindo que qualquer outra requisição seja processada enquanto o LLM gera a resposta. O Gradio reporta "Não foi possível conectar à API" porque o timeout é atingido.
+
+#### Escopo Técnico (!obrigatório)
+- **Arquivos/módulos envolvidos:** `api/routes/chat.py`
+- **Dependências necessárias:** nenhuma
+- **Impacto em funcionalidades existentes:** melhora disponibilidade; comportamento funcional inalterado
+
+#### Critérios de Aceite (!obrigatório)
+- [ ] Endpoint `chat` não bloqueia o event loop do FastAPI
+- [ ] `/health` responde enquanto `/chat` está processando
+- [ ] Testes existentes continuam passando
+- [ ] Ruff lint passa sem erros
+
+#### Restrições
+- Mudança mínima: alterar `async def` para `def` (FastAPI roda em thread pool automaticamente)
+- Não alterar lógica de negócio do pipeline RAG
+
+#### Log de Andamento (atualizado pelo agente)
+
+| Data | Sessão | Ação Realizada | Status ao Final |
+|------|--------|----------------|-----------------|
+| 2026-04-27 | 1 | Diagnóstico: async def com chamadas síncronas bloqueia event loop | em andamento |
+
+---
+
+### TASK-T41
+- **Status:** pendente
+- **Modo:** desenvolvimento
+- **Complexidade:** patch
+- **Data de criação:** 2026-04-27
+
+#### Objetivo (!obrigatório)
+Corrigir `DB_PATH` em `database/db.py` que cria `smartb100_v2.db` no Desktop em vez da raiz do projeto.
+
+#### Contexto (!obrigatório)
+`Path(__file__).resolve().parents[2]` sobe dois níveis a partir de `database/db.py`, resultando no diretório pai do projeto (Desktop). O correto é `.parents[1]` para chegar à raiz do projeto.
+
+#### Escopo Técnico (!obrigatório)
+- **Arquivos/módulos envolvidos:** `database/db.py`
+- **Dependências necessárias:** nenhuma
+- **Impacto em funcionalidades existentes:** altera local do banco SQLite; dados existentes no Desktop não serão migrados automaticamente
+
+#### Critérios de Aceite (!obrigatório)
+- [ ] `smartb100_v2.db` é criado na raiz do projeto (`sb100_agents/`)
+- [ ] Testes existentes continuam passando
+- [ ] Ruff lint passa sem erros
+
+---
+
+### TASK-T42
+- **Status:** pendente
+- **Modo:** desenvolvimento
+- **Complexidade:** patch
+- **Data de criação:** 2026-04-27
+
+#### Objetivo (!obrigatório)
+Corrigir `start.bat` que cria arquivo `nul` na raiz do projeto em vez de redirecionar para o dispositivo nulo do Windows.
+
+#### Contexto (!obrigatório)
+Redirecionamentos `>nul` no `start.bat` são interpretados como nome de arquivo literal em certos contextos do Windows (OneDrive, PowerShell, encoding). Deve-se usar `> NUL` para garantir interpretação correta.
+
+#### Escopo Técnico (!obrigatório)
+- **Arquivos/módulos envolvidos:** `start.bat`
+- **Dependências necessárias:** nenhuma
+- **Impacto em funcionalidades existentes:** nenhum
+
+#### Critérios de Aceite (!obrigatório)
+- [ ] Arquivo `nul` não é criado ao executar `start.bat`
+- [ ] Redirecionamentos usam formato robusto para Windows
+- [ ] Script continua funcional
 
 ---
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -75,7 +75,7 @@ def _get_or_create_buffer(session_id: str) -> ConversationBuffer:
 
 
 @router.post("", response_model=ChatResponse)
-async def chat(req: ChatRequest) -> ChatResponse:
+def chat(req: ChatRequest) -> ChatResponse:
     """Processa pergunta do usuário e retorna resposta do assistente.
 
     Pipeline RAG completo:

--- a/database/db.py
+++ b/database/db.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 # SQLite database file relative to the project root
-DB_PATH = str(Path(__file__).resolve().parents[2] / "smartb100_v2.db")
+DB_PATH = str(Path(__file__).resolve().parents[1] / "smartb100_v2.db")
 
 SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
 

--- a/start.bat
+++ b/start.bat
@@ -3,7 +3,7 @@ echo === SmartB100 Startup ===
 echo.
 
 REM Localizar Ollama dinamicamente via PATH
-for /f "tokens=*" %%i in ('where ollama 2^>nul') do set OLLAMA_EXE=%%i
+for /f "tokens=*" %%i in ('where ollama 2^>NUL') do set OLLAMA_EXE=%%i
 
 if not defined OLLAMA_EXE (
     echo ERRO: Ollama nao encontrado no PATH do sistema.
@@ -23,13 +23,13 @@ if %ERRORLEVEL% EQU 0 (
 
 echo.
 echo [2/4] Verificando modelos Ollama...
-"%OLLAMA_EXE%" list | findstr "nomic-embed-text" >nul
+"%OLLAMA_EXE%" list | findstr "nomic-embed-text" >NUL
 if %ERRORLEVEL% NEQ 0 (
     echo Baixando modelo de embeddings...
     "%OLLAMA_EXE%" pull nomic-embed-text
 )
 
-"%OLLAMA_EXE%" list | findstr "llama3.2:3b" >nul
+"%OLLAMA_EXE%" list | findstr "llama3.2:3b" >NUL
 if %ERRORLEVEL% NEQ 0 (
     echo Baixando modelo de chat...
     "%OLLAMA_EXE%" pull llama3.2:3b
@@ -46,10 +46,10 @@ echo.
 
 echo [4/4] Iniciando servicos...
 start "SmartB100 API" cmd /k ".venv\Scripts\python.exe -m uvicorn api.main:app --reload"
-timeout /t 3 /nobreak >nul
+timeout /t 3 /nobreak >NUL
 start "SmartB100 Gradio" cmd /k ".venv\Scripts\python.exe ui/chat_ui.py"
 
 echo.
 echo Servicos iniciados em janelas separadas.
 echo Pressione qualquer tecla para fechar esta janela...
-pause >nul
+pause >NUL


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** Três bugs identificados durante diagnóstico de conectividade Gradio-API: (1) endpoint `/chat` bloqueava o event loop do FastAPI, impedindo requisições concorrentes; (2) `smartb100_v2.db` era criado no Desktop em vez da raiz do projeto; (3) `start.bat` criava arquivo literal `nul` no Windows.
- **Task ref.:** TASK-T40, TASK-T41, TASK-T42

### 2. O que foi feito?
- [x] **TASK-T40** — `async def chat()` → `def chat()` em `api/routes/chat.py`. FastAPI executa handlers síncronos em thread pool, liberando o event loop para `/health` e outras requisições.
- [x] **TASK-T41** — `.parents[2]` → `.parents[1]` em `database/db.py`. O banco SQLite agora é criado na raiz do projeto (`sb100_agents/smartb100_v2.db`).
- [x] **TASK-T42** — `>nul` → `>NUL` (5 ocorrências) em `start.bat`. Uppercase garante interpretação como dispositivo nulo do Windows.

### 3. Como testar?
1. Baixe a branch: `git checkout fix/TASK-T40-async-blocking-eventloop`
2. Reinicie o uvicorn: `.venv\Scripts\python.exe -m uvicorn api.main:app --reload`
3. Inicie o Gradio: `.venv\Scripts\python.exe ui/chat_ui.py`
4. Verifique:
   - Envie uma pergunta no Gradio — deve receber resposta sem erro de conexão
   - Durante o processamento do `/chat`, acesse `http://localhost:8000/health` — deve responder imediatamente
   - Verifique que `smartb100_v2.db` é criado na pasta `sb100_agents/`, não no Desktop
   - Execute `start.bat` e confirme que nenhum arquivo `nul` é criado na raiz

### 4. Evidências
Mudanças apenas em backend/scripts — sem alterações visuais.

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada