### PR TITLE
fix(ui): increase Gradio timeout to prevent false connection errors

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -521,6 +521,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 24 | 2026-04-27 | TASK-T40 | minor | 1 arquivo — api/routes/chat.py | aprovado | async def → def; event loop desbloqueado |
 | 25 | 2026-04-27 | TASK-T41 | patch | 1 arquivo — database/db.py | aprovado | parents[2] ��� parents[1]; DB na raiz do projeto |
 | 26 | 2026-04-27 | TASK-T42 | patch | 1 arquivo — start.bat | aprovado | >nul → >NUL; evita criação de arquivo literal |
+| 27 | 2026-04-27 | TASK-T43 | patch | 1 arquivo — ui/chat_ui.py | aprovado | REQUEST_TIMEOUT 120s → 300s; LLM local demora ~120s |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -534,7 +535,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 testes unitários)
 - **Divergências externas pendentes:** mudanças pré-existentes em README.md (não commitadas, fora de escopo)
-- **Última task concluída:** TASK-T42 — >nul → >NUL no start.bat
+- **Última task concluída:** TASK-T43 — REQUEST_TIMEOUT 120s → 300s no Gradio
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,7 +84,27 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-[nenhuma task ativa]
+### TASK-T43
+- **Status:** em andamento
+- **Modo:** desenvolvimento
+- **Complexidade:** patch
+- **Data de criação:** 2026-04-27
+
+#### Objetivo (!obrigatório)
+Aumentar REQUEST_TIMEOUT do Gradio para acomodar tempo de geração do LLM local.
+
+#### Contexto (!obrigatório)
+O Ollama com llama3.2:3b leva ~120s para gerar respostas com contexto RAG. O timeout do httpx no Gradio é exatamente 120s, causando falha intermitente por timeout. O erro exibido é "Não foi possível conectar à API" mas a causa real é timeout de leitura.
+
+#### Escopo Técnico (!obrigatório)
+- **Arquivos/módulos envolvidos:** `ui/chat_ui.py`
+- **Dependências necessárias:** nenhuma
+- **Impacto em funcionalidades existentes:** nenhum — apenas aumenta tolerância de espera
+
+#### Critérios de Aceite (!obrigatório)
+- [ ] REQUEST_TIMEOUT suficiente para geração local com llama3.2:3b (~120s)
+- [ ] Ruff lint passa sem erros
+- [ ] Testes existentes continuam passando
 
 ---
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,33 +84,20 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T43
-- **Status:** em andamento
-- **Modo:** desenvolvimento
-- **Complexidade:** patch
-- **Data de criação:** 2026-04-27
-
-#### Objetivo (!obrigatório)
-Aumentar REQUEST_TIMEOUT do Gradio para acomodar tempo de geração do LLM local.
-
-#### Contexto (!obrigatório)
-O Ollama com llama3.2:3b leva ~120s para gerar respostas com contexto RAG. O timeout do httpx no Gradio é exatamente 120s, causando falha intermitente por timeout. O erro exibido é "Não foi possível conectar à API" mas a causa real é timeout de leitura.
-
-#### Escopo Técnico (!obrigatório)
-- **Arquivos/módulos envolvidos:** `ui/chat_ui.py`
-- **Dependências necessárias:** nenhuma
-- **Impacto em funcionalidades existentes:** nenhum — apenas aumenta tolerância de espera
-
-#### Critérios de Aceite (!obrigatório)
-- [ ] REQUEST_TIMEOUT suficiente para geração local com llama3.2:3b (~120s)
-- [ ] Ruff lint passa sem erros
-- [ ] Testes existentes continuam passando
+[nenhuma task ativa]
 
 ---
 
 ## Tasks Concluídas
 
-> Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico �� cumulativo.
+> Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T43 — Aumentar REQUEST_TIMEOUT do Gradio ✓
+- **Concluída em:** 2026-04-27
+- **Branch:** fix/TASK-T43-gradio-timeout
+- **Commit:** d975911
+- **Avaliação:** aprovado
+- **Nota:** Timeout aumentado de 120s para 300s. Ollama llama3.2:3b leva ~120s com contexto RAG, causando timeout intermitente.
 
 ### TASK-T42 — Corrigir redirecionamento >nul no start.bat ✓
 - **Concluída em:** 2026-04-27

--- a/ui/chat_ui.py
+++ b/ui/chat_ui.py
@@ -24,7 +24,7 @@ import httpx
 
 DEFAULT_API_URL = "http://localhost:8000"
 DEFAULT_PORT = 7860
-REQUEST_TIMEOUT = 120.0
+REQUEST_TIMEOUT = 300.0
 
 
 class ChatSession:


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** O Gradio reportava "Não foi possível conectar à API" porque o `REQUEST_TIMEOUT` do httpx (120s) era insuficiente para o tempo de geração do Ollama llama3.2:3b com contexto RAG (~120s). A requisição expirava antes da API retornar.
- **Task ref.:** TASK-T43

### 2. O que foi feito?
- [x] `REQUEST_TIMEOUT` aumentado de 120s para 300s em `ui/chat_ui.py`

### 3. Como testar?
1. Baixe a branch: `git checkout fix/TASK-T43-gradio-timeout`
2. Reinicie o Gradio: `.venv\Scripts\python.exe ui/chat_ui.py`
3. Envie uma pergunta no chat
4. Verifique que a resposta é exibida sem erro de conexão (pode levar ~60-120s)

### 4. Evidências
Teste direto com httpx confirmou que a API responde com status 200 em ~122s — acima do timeout anterior de 120s.

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada