### PR TITLE
fix(ui): improve timeout and error messages for CPU-only Ollama

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -523,6 +523,7 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 | 26 | 2026-04-27 | TASK-T42 | patch | 1 arquivo — start.bat | aprovado | >nul → >NUL; evita criação de arquivo literal |
 | 27 | 2026-04-27 | TASK-T43 | patch | 1 arquivo — ui/chat_ui.py | aprovado | REQUEST_TIMEOUT 120s → 300s; LLM local demora ~120s |
 | 28 | 2026-04-27 | TASK-T45 | minor | 2 arquivos — verification/entropy.py, core/config.py | aprovado | Verificação migrada de OpenAI para multi-provedor (Groq/Ollama/OpenRouter); embeddings via Ollama local |
+| 29 | 2026-04-27 | TASK-T44 | minor | 3 arquivos — ui/chat_ui.py, generation/llm.py, README.md | aprovado | Timeout 600s, TimeoutException separada, num_predict no Ollama |
 
 > **Escopo Alterado:** Registre de forma resumida — quantidade de arquivos e módulo afetado. Ex: "3 arquivos — módulo auth", "1 arquivo — config". O detalhamento completo de arquivos fica no Log de Andamento da task em `tasks.md` e no diff do commit.
 
@@ -535,8 +536,8 @@ Decisão: [seguro para prosseguir / requer atenção do usuário]
 - **Branch ativa:** fix/TASK-T44-timeout-error-messages
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18/18 unitários + 7/7 integração)
-- **Divergências externas pendentes:** mudanças pré-existentes em README.md, core/config.py, generation/llm.py, ui/chat_ui.py (TASK-T44 em andamento)
-- **Última task concluída:** TASK-T45 — Verificação de alucinação migrada para provedores opensource
+- **Divergências externas pendentes:** nenhuma
+- **Última task concluída:** TASK-T44 — Timeout, mensagens de erro e performance CPU
 
 ### 9.5 Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,54 +84,8 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T45
-- **Status:** concluída
-- **Modo:** desenvolvimento
-- **Complexidade:** minor
-- **Data de criação:** 2026-04-27
-
-#### Objetivo (!obrigatório)
-Migrar verificação de alucinação de OpenAI para provedores opensource (Groq, Ollama, OpenRouter) com padrão de dispatch multi-provedor.
-
-#### Contexto (!obrigatório)
-Verificação inoperante: `OPENAI_API_KEY` vazia faz `hallucination_score` retornar sempre `0.0`. Groq e OpenRouter já estão configurados no `.env`. O padrão de dispatch por provider já é usado em `eval/judge.py`, `eval/collect_references.py` e `eval/generate_questions.py`.
-
-#### Escopo Técnico (!obrigatório)
-- **Arquivos/módulos envolvidos:** verification/entropy.py, core/config.py
-- **Dependências necessárias:** nenhuma (groq, openai, ollama já são dependências do projeto)
-- **Impacto em funcionalidades existentes:** verification/gate.py usa compute_entropy_score como caixa preta — interface mantida
-
-#### Critérios de Aceite (!obrigatório)
-- [ ] OpenAI removida como dependência de verification/entropy.py
-- [ ] Suporte a 3 providers: groq, ollama, openrouter (dispatch dict)
-- [ ] Embeddings via Ollama local (nomic-embed-text) em vez de OpenAI
-- [ ] NUM_SAMPLES configurável via settings (default 2)
-- [ ] Settings adicionados: verification_provider, verification_chat_model, entropy_num_samples
-- [ ] ruff check e ruff format passam sem erros
-- [ ] pytest tests/ passa sem regressões
-
-#### Restrições (opcional)
-- Não alterar verification/gate.py, api/routes/chat.py, generation/llm.py
-- Manter assinatura de compute_entropy_score(question, context) -> float
-- Seguir padrão de dispatch existente em eval/
-
-#### Log de Andamento (atualizado pelo agente)
-
-| Data | Sessão | Ação Realizada | Status ao Final |
-|------|--------|----------------|-----------------|
-| 2026-04-27 | 1 | Implementação completa: config.py + entropy.py reescritos, lint + tests OK | concluída |
-
-#### Resultado (preenchido ao concluir)
-- **Data de conclusão:** 2026-04-27
-- **Branch:** fix/TASK-T44-timeout-error-messages (compartilhada com T44)
-- **Commit(s):** pendente de commit pelo desenvolvedor
-- **Avaliação pós-implementação:** aprovado
-- **Observações:** OpenAI removida de entropy.py. 3 providers (Groq/Ollama/OpenRouter) com dispatch dict. Embeddings via Ollama local. NUM_SAMPLES reduzido de 5 para 2 (configurável). 25/25 testes passando.
-
----
-
 ### TASK-T44
-- **Status:** em andamento
+- **Status:** concluída
 - **Modo:** desenvolvimento
 - **Complexidade:** minor
 - **Data de criação:** 2026-04-27
@@ -162,13 +116,14 @@ O LLM local (llama3.2:3b no Ollama) leva ~163s por resposta em CPU. O timeout do
 | Data | Sessão | Ação Realizada | Status ao Final |
 |------|--------|----------------|-----------------|
 | 2026-04-27 | 1 | Diagnóstico: LLM ~163s em CPU, timeout 300s insuficiente, mensagem de erro genérica | em andamento |
+| 2026-04-27 | 2 | Implementação: timeout 600s, TimeoutException separada, num_predict em llm.py, lint fix f-string | concluída |
 
 #### Resultado (preenchido ao concluir)
-- **Data de conclusão:** —
-- **Branch:** —
-- **Commit(s):** —
-- **Avaliação pós-implementação:** —
-- **Observações:** —
+- **Data de conclusão:** 2026-04-27
+- **Branch:** fix/TASK-T44-timeout-error-messages
+- **Commit(s):** pendente
+- **Avaliação pós-implementação:** aprovado
+- **Observações:** Timeout 300→600s. TimeoutException com mensagem CPU-friendly. num_predict limita tokens no Ollama. README com ajustes cosméticos de setup.
 
 ---
 
@@ -176,10 +131,17 @@ O LLM local (llama3.2:3b no Ollama) leva ~163s por resposta em CPU. O timeout do
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (instructions.md Seção 9). Nunca remova entradas — o histórico é cumulativo.
 
-### TASK-T45 — Migrar verificação de alucinação para provedores opensource ✓
+### TASK-T44 — Timeout, mensagens de erro e performance CPU ✓
 - **Concluída em:** 2026-04-27
 - **Branch:** fix/TASK-T44-timeout-error-messages
 - **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** Timeout 300→600s. TimeoutException separada com mensagem CPU-friendly. num_predict limita tokens no Ollama. f-string lint fix.
+
+### TASK-T45 — Migrar verificação de alucinação para provedores opensource ✓
+- **Concluída em:** 2026-04-27
+- **Branch:** feat/TASK-T45-verification-opensource
+- **Commit:** 6b7ea73
 - **Avaliação:** aprovado
 - **Nota:** OpenAI substituída por Groq/Ollama/OpenRouter com dispatch dict. Embeddings via Ollama local. NUM_SAMPLES 5 → 2 (configurável). 25/25 testes passando.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ uv sync
 
 # Option B: pip
 python -m venv .venv
-.venv\Scripts\pip install -e .     # Windows
+.venv\Scripts\pip install -e .     # Windows (Dont forget the dot at the end!)
 .venv/bin/pip install -e .         # Linux/Mac
 ```
 
@@ -79,7 +79,7 @@ python -m venv .venv
 ```bash
 # Copy the example file (required — the API will not start without it)
 cp .env.example .env               # Linux/Mac
-copy .env.example .env             # Windows
+copy .env.example .env             # Windows 
 ```
 The default values in `.env.example` work for local development. Edit `.env` only if you need to change model names, Qdrant URL, or add API keys for the evaluation pipeline. See `SETUP.md` for remote Qdrant configuration.
 

--- a/generation/llm.py
+++ b/generation/llm.py
@@ -69,6 +69,10 @@ def generate(
     )
     messages.append({"role": "user", "content": user_content})
 
-    response = ollama.chat(model=settings.chat_model, messages=messages)
+    response = ollama.chat(
+        model=settings.chat_model,
+        messages=messages,
+        options={"num_predict": settings.llm_max_tokens},
+    )
 
     return str(response["message"]["content"])

--- a/ui/chat_ui.py
+++ b/ui/chat_ui.py
@@ -24,7 +24,7 @@ import httpx
 
 DEFAULT_API_URL = "http://localhost:8000"
 DEFAULT_PORT = 7860
-REQUEST_TIMEOUT = 300.0
+REQUEST_TIMEOUT = 600.0  # CPU-only Ollama: ~160-200s per response; GPU: ~10-30s
 
 
 class ChatSession:
@@ -151,13 +151,24 @@ def create_interface(api_url: str) -> gr.Blocks:
             ]
             yield history, error_msg
 
+        except httpx.TimeoutException:
+            error_msg = "Timeout: a API demorou demais para responder. O LLM local pode estar lento (CPU-only leva ~3-5 min por resposta)."
+            history = history + [
+                {"role": "user", "content": message},
+                {
+                    "role": "assistant",
+                    "content": "Erro: Timeout ao aguardar resposta da API. Se o Ollama esta rodando em CPU, a geracao pode levar varios minutos. Tente novamente ou considere usar um modelo menor.",
+                },
+            ]
+            yield history, error_msg
+
         except httpx.RequestError as e:
             error_msg = f"Erro de conexão: {e}"
             history = history + [
                 {"role": "user", "content": message},
                 {
                     "role": "assistant",
-                    "content": f"Erro: Não foi possível conectar à API em {api_url}",
+                    "content": f"Erro: Não foi possível conectar à API em {api_url}. Verifique se o servidor está rodando.",
                 },
             ]
             yield history, error_msg


### PR DESCRIPTION
### 1. Contexto
- **Motivacao:** LLM local (llama3.2:3b) leva ~160-200s em CPU. Timeout de 300s pode estourar em perguntas complexas. Mensagem de erro generica confunde usuario (timeout vs conexao).
- **Task ref.:** TASK-T44

### 2. O que foi feito?
- [x] Timeout httpx aumentado de 300s para 600s em `ui/chat_ui.py`
- [x] `httpx.TimeoutException` capturada separadamente de `httpx.RequestError` com mensagem especifica
- [x] `num_predict: settings.llm_max_tokens` passado ao Ollama em `generation/llm.py` (limita tokens por resposta)
- [x] Comentario documentando tempos CPU vs GPU
- [x] Ajustes cosmeticos no README (setup comments)

### 3. Como testar?
1. Baixe a branch: `git checkout fix/TASK-T44-timeout-error-messages`
2. Suba Qdrant + API + Gradio normalmente
3. Envie uma pergunta pela UI
4. Verifique: resposta retorna sem timeout; se timeout ocorrer, mensagem menciona CPU/modelo lento
5. Simule erro de conexao (API desligada): mensagem diferencia de timeout

### 4. Evidencias
Backend + UI textual — sem mudancas visuais significativas.

### 5. Checklist de Auto-Revisao
- [x] Realizei a auto-revisao na aba "Files Changed"
- [x] Removi codigos comentados e console.logs desnecessarios
- [x] O codigo segue o guia de estilo do projeto
- [x] As novas dependencias funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliacao pos-implementacao foi executada e aprovada