### PR TITLE
fix(db): reject smartb100_v2.db as directory and ignore local sqlite file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ build/
 .env
 .env.local
 
+# SQLite (local dev; never commit DB contents)
+smartb100_v2.db
+
 # Qdrant storage (optional - uncomment if you want to track)
 /qdrant_storage
 

--- a/database/db.py
+++ b/database/db.py
@@ -5,9 +5,18 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 # SQLite database file relative to the project root
-DB_PATH = str(Path(__file__).resolve().parents[1] / "smartb100_v2.db")
-
-SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
+_db_path = Path(__file__).resolve().parents[1] / "smartb100_v2.db"
+if _db_path.exists() and _db_path.is_dir():
+    msg = (
+        f"SQLite path {_db_path} is a directory, not a database file. "
+        "Delete that folder. On Windows, a Docker bind mount to a missing path can create "
+        "a directory with this name: create an empty file first, or remove the bad folder."
+    )
+    raise RuntimeError(msg)
+_resolved_db = _db_path.resolve()
+DB_PATH = str(_resolved_db)
+# Barras à frente no URL evitam ambiguidade do SQLite no Windows (recomendado pelo SQLAlchemy).
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{_resolved_db.as_posix()}"
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
### 1. Contexto

- **Motivação:** Com `smartb100_v2.db` como **diretório** (comum no Windows quando o Docker faz bind mount de um path que ainda não existia como ficheiro), o SQLite falhava com `unable to open database file` e a API não subia no startup (`Base.metadata.create_all`).
- **Link da Tarefa:** —
- **Task ref.:** TASK-T46 (registo em `.claude/tasks.md`)

### 2. O que foi feito?

- [ ] Validação em `database/db.py`: se o path de `smartb100_v2.db` existir e for **diretório**, levanta `RuntimeError` com mensagem que explica a causa e a mitigação (bind mount Docker no Windows).
- [ ] Entrada em `.gitignore` para **não versionar** `smartb100_v2.db` (base local de desenvolvimento).
- [ ] Atualização do registo do projeto em `.claude/instructions.md` (histórico / pendências sobre bind mount), conforme fluxo do repositório.

### 3. Como testar?

1. Baixe a branch: `git checkout fix/TASK-T46-sqlite-directory` *(ajusta ao nome real da branch)*
2. Instale as dependências: `uv sync`
3. Garanta na raiz do projeto um **ficheiro** `smartb100_v2.db` (não pasta); suba a API: `.venv\Scripts\python.exe -m uvicorn api.main:app --reload`
4. Verifique: startup completa sem `unable to open database file`; `GET /health` retorna OK; se criar de propósito uma pasta com o nome `smartb100_v2.db`, o processo deve falhar com a **nova** `RuntimeError` explícita.

### 4. Evidências

N/A — alteração apenas de backend e configuração local; sem UI.

### 5. Checklist de Auto-Revisão

- [ ] Realizei a auto-revisão na aba "Files Changed"
- [ ] Removi códigos comentados e console.logs desnecessários
- [ ] O código segue o guia de estilo do projeto
- [ ] As novas dependências funcionam sem quebrar o build atual *(nenhuma nova dependência nesta task)*
- [ ] Nomes seguem o VAR Method
- [ ] Commits seguem Conventional Commits (sem body, sem co-auth)
- [ ] Avaliação pós-implementação foi executada e aprovada