### PR TITLE
ci(workflows): add Claude Code auto-implement and respond workflows

### DIFF
--- a/.claude/registry.md
+++ b/.claude/registry.md
@@ -52,6 +52,7 @@
 | 32 | 2026-04-27 | TASK-T48 | patch | 1 arquivo — retrieval/ollama_embeddings.py | aprovado | Variável tipada resolve mypy no-any-return; CI typecheck desbloqueado |
 | 33 | 2026-04-27 | TASK-T49 | major | 22 arquivos — .claude/ reestruturado | aprovado | Migração instructions.md monolítico para rules/ modular + registry.md separado |
 | 34 | 2026-04-27 | TASK-T50 | minor | 3 arquivos — CONTRIBUTING.md, LICENSE, README.md | aprovado | Guia contribuição open-source + MIT License + seção Contribuindo no README |
+| 35 | 2026-04-27 | TASK-T51 | major | 3 arquivos — .github/workflows/claude-auto.yml, claude-respond.yml, README.md | aprovado | GitHub Actions: auto-implementação de issues (claude-auto label) + resposta interativa (@claude) via anthropics/claude-code-action@v1 |
 
 ## Estado da Codebase
 
@@ -59,11 +60,11 @@
 
 - **Última atualização:** 2026-04-27
 - **Último responsável:** Assistente (sessão local)
-- **Branch ativa:** refactor/TASK-T49-modular-claude-rules
+- **Branch ativa:** ci/TASK-T51-claude-auto-action
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (18 unitários, `pytest -o addopts=`)
 - **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** TASK-T50 — CONTRIBUTING.md, seção README e LICENSE MIT
+- **Última task concluída:** TASK-T51 — GitHub Action + Claude Code para Auto-Implementação de Issues
 
 ## Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,11 +84,16 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
----
-
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (`registry.md`). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T51 — GitHub Action + Claude Code para Auto-Implementação de Issues ✓
+- **Concluída em:** 2026-04-27
+- **Branch:** ci/TASK-T51-claude-auto-action
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** Dois workflows: `claude-auto.yml` (label trigger, branch+PR automáticos via anthropics/claude-code-action@v1) e `claude-respond.yml` (@claude em comentários). README atualizado com seção de automação e setup. CI existente inalterado. Sem auto-merge — PR sempre requer review humano.
 
 ### TASK-T50 — CONTRIBUTING.md, seção README e LICENSE MIT ✓
 - **Concluída em:** 2026-04-27

--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -1,0 +1,112 @@
+name: Claude Auto-Implement
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: |
+      github.event.label.name == 'claude-auto' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.sender.association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Validate issue content
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          if [ -z "$ISSUE_TITLE" ]; then
+            echo "::error::Issue title is empty"
+            exit 1
+          fi
+          if [ ${#ISSUE_BODY} -lt 20 ]; then
+            echo "::error::Issue body too short (min 20 chars)"
+            exit 1
+          fi
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          label_trigger: "claude-auto"
+          base_branch: "main"
+          branch_prefix: "claude/"
+          prompt: |
+            You are implementing a solution for GitHub issue #${{ github.event.issue.number }}.
+
+            ISSUE TITLE: ${{ github.event.issue.title }}
+            ISSUE BODY:
+            ${{ github.event.issue.body }}
+
+            INSTRUCTIONS:
+            1. Read CLAUDE.md at the repository root for project conventions.
+            2. Implement the solution following existing patterns and architecture.
+            3. Use Conventional Commits: type(scope): subject (single line, no body, no co-authored-by).
+            4. Run tests: pytest tests/ -v --ignore=tests/test_integration.py
+            5. Run lint: ruff check . && ruff format --check .
+            6. Fix any failures before finishing.
+            7. Keep changes minimal — only modify what is necessary.
+            8. Do not add unnecessary dependencies.
+            9. If the issue is unclear, comment explaining what is ambiguous instead of guessing.
+            10. PR description must include: summary of changes, "Closes #${{ github.event.issue.number }}", how to test.
+          claude_args: >-
+            --max-turns ${{ vars.CLAUDE_MAX_TURNS || '25' }}
+            --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+
+      - name: Comment result on issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = '${{ steps.claude.outputs.branch_name }}';
+            const success = '${{ steps.claude.outcome }}' === 'success';
+            if (success && branchName) {
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branchName}`,
+                state: 'open'
+              });
+              if (prs.length > 0) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `Claude Code created PR #${prs[0].number} to address this issue.\n\n**Branch:** \`${branchName}\`\n\nPlease review before merging.`
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Claude Code was unable to implement this issue automatically.\n\n[Workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n\nThis issue may require manual implementation.`
+              });
+            }
+
+      - name: Remove label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'claude-auto'
+              });
+            } catch (e) { /* label may already be removed */ }

--- a/.github/workflows/claude-respond.yml
+++ b/.github/workflows/claude-respond.yml
@@ -1,0 +1,33 @@
+name: Claude Respond
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  respond:
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.sender.association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude"
+          claude_args: >-
+            --max-turns ${{ vars.CLAUDE_MAX_TURNS || '15' }}
+            --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}

--- a/README.md
+++ b/README.md
@@ -207,7 +207,10 @@ sb100_agents/
 ├── tests/                          # Unit + integration tests
 ├── scripts/
 │   └── ingest.py                   # PDF ingestion wrapper
-├── .github/workflows/ci.yml        # GitHub Actions CI pipeline
+├── .github/workflows/
+│   ├── ci.yml                      # GitHub Actions CI pipeline
+│   ├── claude-auto.yml             # Auto-implement issues (claude-auto label)
+│   └── claude-respond.yml          # Interactive @claude in comments
 ├── ARCHITECTURE.md
 ├── SETUP.md                        # Detailed setup guide (local/remote Qdrant)
 ├── docker-compose.yml              # Docker services (infra: Qdrant / app: API+Gradio)
@@ -324,6 +327,26 @@ curl -X POST "http://localhost:8000/chat" \
 # Health check
 curl "http://localhost:8000/health"
 ```
+
+## Automated Issue Implementation
+
+Issues can be automatically implemented by Claude Code via GitHub Actions.
+
+### How it works
+1. Create an issue with clear requirements and acceptance criteria
+2. Apply the `claude-auto` label
+3. Claude Code reads the issue, creates a branch, implements the solution, and opens a PR
+4. Review the PR and merge if satisfactory
+
+### Interactive mode
+Mention `@claude` in any issue or PR comment to get Claude's assistance.
+
+### Setup (repository admin)
+1. Add `ANTHROPIC_API_KEY` secret in Settings > Secrets > Actions
+2. Create `claude-auto` label in Issues > Labels
+3. (Optional) Configure variables in Settings > Variables > Actions:
+   - `CLAUDE_MAX_TURNS` (default: 25)
+   - `CLAUDE_MODEL` (default: claude-sonnet-4-6)
 
 ## Contributing
 


### PR DESCRIPTION
### 1. Contexto
- **Motivação:** Automação para resolver issues de forma autônoma via Claude Code, disparada por label no GitHub
- **Task ref.:** TASK-T51

### 2. O que foi feito?
- [x] Workflow `claude-auto.yml` — label `claude-auto` dispara Claude Code para ler issue, criar branch, implementar e abrir PR
- [x] Workflow `claude-respond.yml` — menção `@claude` em comentários de issues/PRs dispara resposta interativa
- [x] README.md atualizado com seção "Automated Issue Implementation" e Project Structure
- [x] `tasks.md` e `registry.md` atualizados

### 3. Como testar?
1. Baixe a branch: `git checkout ci/TASK-T51-claude-auto-action`
2. Verifique os workflows em `.github/workflows/claude-auto.yml` e `claude-respond.yml`
3. Após merge, configure: `ANTHROPIC_API_KEY` secret + label `claude-auto`
4. Crie uma issue de teste, aplique a label, verifique na aba Actions

### 4. Evidências
Apenas workflows YAML e documentação — sem mudanças visuais.

### 5. Checklist de Auto-Revisão
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes seguem o VAR Method
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada