### PR TITLE
feat(chat): TASK-T65 — thread-safe session cache and buffer validation

### DIFF
--- a/.claude/registry.md
+++ b/.claude/registry.md
@@ -66,20 +66,21 @@
 | 46 | 2026-05-26 | TASK-T62 | minor | 4 arquivos — core/config.py, core/schemas.py, tests/test_schemas.py, tests/test_config.py (novo) | aprovado | Validações rigorosas: `VerificationProvider(StrEnum)`, `Field(ge/le)` em top_k/buffer_maxlen/llm_max_tokens/hallucination_threshold/entropy_num_samples, API keys `str \| None`, schemas com bounds (session_id, name, hallucination_score). 26 novos testes. 90 testes (era 64), cobertura 70.82%. |
 | 47 | 2026-05-26 | TASK-T63 | minor | 4 arquivos — database/models.py, database/db.py, tests/test_db.py (novo), README.md | aprovado | Integridade SQLAlchemy: NOT NULL em campos obrigatórios, index em FKs, ondelete=CASCADE + passive_deletes, Boolean em is_hallucinated, DateTime(timezone=True), connect_args timeout=10, PRAGMA foreign_keys=ON via event listener, get_db rollback-on-exception. 11 novos testes (NULL, CASCADE, tz, rollback). 101 testes, cobertura 70.82%. Breaking: schemas legados ficam frouxos — recriar `smartb100_v2.db`. |
 | 48 | 2026-05-26 | TASK-T64 | minor | 4 arquivos — verification/entropy.py, verification/gate.py, core/config.py, tests/test_verification.py (novo) | aprovado | Estabilidade verificação: epsilon 1e-10 em cosseno, logger.warning em missing API key, try/except parcial em samples, resp.get safe access em ollama, validação provider antes de dispatch, gate fallback score=0.5 em falha de entropia, entropy_temperature em Settings (ge=0.0, le=2.0). 13 novos testes. 114 testes, cobertura 81.37%. mypy strict agora limpo em verification/entropy.py (resolve parte da T74). |
+| 49 | 2026-05-26 | TASK-T65 | minor | 4 arquivos — api/routes/chat.py, memory/conversation.py, tests/test_conversation.py, tests/test_chat_concurrency.py (novo) | aprovado | Thread-safety: `_sessions_lock = threading.Lock()` envolve cleanup/eviction/lookup em `_get_or_create_buffer`; `del` → `.pop(sid, None)`. `ConversationBuffer.add()` valida role em `{"user", "assistant"}` e content não-vazio (ValueError). 6 novos testes (validação + 3 de concorrência ThreadPoolExecutor 50 threads). 120 testes, cobertura 81.84%. |
 
 ## Estado da Codebase
 
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
-- **Última atualização:** 2026-05-26 (TASK-T64 — estabilidade numérica em verification)
+- **Última atualização:** 2026-05-26 (TASK-T65 — thread-safety em /chat _sessions)
 - **Último responsável:** Assistente (sessão local)
-- **Branch ativa:** feat/TASK-T64-verification-stability (empilhada sobre T63; PR pendente)
-- **Dependências alteradas recentemente:** passlib[bcrypt], bcrypt (<5), slowapi (T60). T59 deps ainda em PR #68
-- **Testes passando:** sim — 114 passed, cobertura 81.37% (≥23%); ruff + format + mypy strict em **todos** os módulos críticos (api, core, verification, retrieval, generation, memory) ok (verificado 2026-05-26)
-- **Divergências externas pendentes:** PR #68 (T59), #69 (T60), #70 (T61), #71 (T62), #72 (T63); T64 ainda local
-- **Última task concluída:** TASK-T64 — verification estabilidade (epsilon, warnings, partial-retry, gate fallback, entropy_temperature)
-- **Backlog ativo:** 10 tasks pendentes (T65 ativa — thread-safety cache /chat; T66–T74 enfileiradas)
-- **PRs abertos:** #68, #69, #70, #71, #72; PR T64 a abrir após push
+- **Branch ativa:** feat/TASK-T65-sessions-thread-safety (a partir de main pós-merge T60-T64)
+- **Dependências alteradas recentemente:** passlib[bcrypt], bcrypt (<5), slowapi (T60) — agora em main
+- **Testes passando:** sim — 120 passed, cobertura 81.84% (≥23%); ruff + format + mypy strict em todos críticos ok (verificado 2026-05-26)
+- **Divergências externas pendentes:** PRs #68-#73 todos mergeados em main; T65 local
+- **Última task concluída:** TASK-T65 — thread-safety _sessions + validação ConversationBuffer
+- **Backlog ativo:** 9 tasks pendentes (T66 ativa — singleton QdrantClient + validação dim; T67–T74 enfileiradas)
+- **PRs abertos:** nenhum (#68-#73 mergeados); PR T65 a abrir após push
 
 ## Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,34 +84,6 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T65
-- **Status:** pendente
-- **Modo:** desenvolvimento
-- **Complexidade:** minor
-- **Data de criação:** 2026-05-26
-
-#### Objetivo
-Thread-safety no cache `_sessions` da rota /chat e validação no ConversationBuffer (issue #54).
-
-#### Contexto
-`api/routes/chat.py:35` usa `OrderedDict` sem sync. FastAPI thread pool em handler sync gera race conditions (check-then-create). Buffer aceita roles/content arbitrários.
-
-#### Escopo Técnico
-- **Arquivos/módulos envolvidos:** `api/routes/chat.py`, `memory/conversation.py`, `tests/`
-- **Dependências necessárias:** nenhuma (threading da stdlib)
-- **Impacto em funcionalidades existentes:** nenhum
-
-#### Critérios de Aceite
-- [ ] `_sessions_lock = threading.Lock()` (ou RLock) em `chat.py`
-- [ ] `with _sessions_lock:` envolvendo todas operações em `_get_or_create_buffer()`
-- [ ] `_sessions.pop(sid, None)` substitui `del`
-- [ ] `ConversationBuffer.add()` valida `role in ("user", "assistant")` e `content` não vazio (ValueError)
-- [ ] Teste de concorrência com `concurrent.futures.ThreadPoolExecutor` (50 requests no mesmo session_id)
-- [ ] `pytest`, `ruff`, `mypy` passam
-
-#### Referências
-- Issue: https://github.com/LukeSantossz/sb100_agents/issues/54
-
 ### TASK-T66
 - **Status:** pendente
 - **Modo:** desenvolvimento
@@ -400,6 +372,20 @@ A verificacao atual mostrou que `ruff check .` passa, mas `mypy retrieval/ gener
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (`registry.md`). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T65 — Thread-safety em /chat _sessions + validação ConversationBuffer ✓
+- **Concluída em:** 2026-05-26
+- **Branch:** feat/TASK-T65-sessions-thread-safety
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** `api/routes/chat.py`: `_sessions_lock = threading.Lock()` e `with _sessions_lock:` envolve todo `_get_or_create_buffer` (expiry cleanup + LRU eviction + pop/insert). `del _sessions[sid]` substituído por `.pop(sid, None)` (idempotente, sem KeyError). `memory/conversation.py`: `ConversationBuffer.add()` levanta `ValueError` para role fora de `{"user", "assistant"}` ou content vazio/whitespace. 3 novos testes em `tests/test_conversation.py` (role inválido, content vazio, roles válidos); 3 testes de concorrência em `tests/test_chat_concurrency.py` (ThreadPoolExecutor 50 threads/mesmo session_id → 1 buffer único; 50 session_ids distintos → 50 buffers; idempotência sequencial). 120 testes (era 114), cobertura 81.84%.
+
+#### Log de Andamento
+
+| Data | Sessão | Ação Realizada | Status ao Final |
+|------|--------|----------------|-----------------|
+| 2026-05-26 | 1 | Reconhecimento (chat.py, conversation.py), branch criada | em andamento |
+| 2026-05-26 | 1 | Implementação (Lock, pop, ValueError), 6 testes, validações OK | concluída |
 
 ### TASK-T64 — Estabilidade numérica e error handling em verification ✓
 - **Concluída em:** 2026-05-26

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -14,6 +14,7 @@ Cache de sessões:
     - Máximo: 1000 sessões simultâneas (LRU eviction).
 """
 
+import threading
 import time
 from collections import OrderedDict
 
@@ -35,6 +36,7 @@ _SESSION_TTL_SECONDS = 3600  # 1 hora
 _SESSION_MAX_SIZE = 1000
 
 _sessions: OrderedDict[str, tuple[ConversationBuffer, float]] = OrderedDict()
+_sessions_lock = threading.Lock()
 
 
 def _get_or_create_buffer(session_id: str) -> ConversationBuffer:
@@ -42,6 +44,9 @@ def _get_or_create_buffer(session_id: str) -> ConversationBuffer:
 
     Implementa cache LRU com TTL para gerenciar memória de sessões.
     Cleanup lazy de sessões expiradas (até 10 por chamada).
+
+    Thread-safe: todas as operações sobre ``_sessions`` ocorrem sob
+    ``_sessions_lock`` para evitar race conditions no thread pool do FastAPI.
 
     Args:
         session_id: Identificador único da sessão.
@@ -51,29 +56,31 @@ def _get_or_create_buffer(session_id: str) -> ConversationBuffer:
     """
     now = time.time()
 
-    # Cleanup de sessões expiradas (lazy, até 10 por chamada)
-    expired = []
-    for sid, (_, ts) in list(_sessions.items())[:10]:
-        if now - ts > _SESSION_TTL_SECONDS:
-            expired.append(sid)
-        else:
-            break  # OrderedDict mantém ordem de inserção
-    for sid in expired:
-        del _sessions[sid]
+    with _sessions_lock:
+        # Cleanup de sessões expiradas (lazy, até 10 por chamada)
+        expired = []
+        for sid, (_, ts) in list(_sessions.items())[:10]:
+            if now - ts > _SESSION_TTL_SECONDS:
+                expired.append(sid)
+            else:
+                break  # OrderedDict mantém ordem de inserção
+        for sid in expired:
+            _sessions.pop(sid, None)
 
-    # Enforce max size (remove mais antigas)
-    while len(_sessions) >= _SESSION_MAX_SIZE:
-        _sessions.popitem(last=False)
+        # Enforce max size (remove mais antigas)
+        while len(_sessions) >= _SESSION_MAX_SIZE:
+            _sessions.popitem(last=False)
 
-    # Recupera ou cria
-    if session_id in _sessions:
-        buffer, _ = _sessions.pop(session_id)  # Remove para reinserir no final
+        # Recupera ou cria
+        existing = _sessions.pop(session_id, None)
+        if existing is not None:
+            buffer, _ = existing
+            _sessions[session_id] = (buffer, now)
+            return buffer
+
+        buffer = ConversationBuffer(maxlen=settings.buffer_maxlen)
         _sessions[session_id] = (buffer, now)
         return buffer
-
-    buffer = ConversationBuffer(maxlen=settings.buffer_maxlen)
-    _sessions[session_id] = (buffer, now)
-    return buffer
 
 
 @router.post("", response_model=ChatResponse)

--- a/memory/conversation.py
+++ b/memory/conversation.py
@@ -2,6 +2,8 @@
 
 from collections import deque
 
+_VALID_ROLES: frozenset[str] = frozenset({"user", "assistant"})
+
 
 class ConversationBuffer:
     """Buffer de histórico de conversa com comportamento FIFO.
@@ -22,15 +24,23 @@ class ConversationBuffer:
         """Adiciona um turno ao buffer.
 
         Args:
-            role: Papel do turno ("user" ou "assistant").
-            content: Conteúdo da mensagem.
+            role: Papel do turno (``"user"`` ou ``"assistant"``).
+            content: Conteúdo da mensagem (não pode ser vazio ou só whitespace).
+
+        Raises:
+            ValueError: Se ``role`` não estiver em ``{"user", "assistant"}`` ou
+                se ``content`` for vazio.
         """
+        if role not in _VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(_VALID_ROLES)}; got {role!r}")
+        if not content or not content.strip():
+            raise ValueError("content must be a non-empty string")
         self._buffer.append({"role": role, "content": content})
 
     def to_messages(self) -> list[dict[str, str]]:
         """Retorna o histórico como lista de mensagens.
 
         Returns:
-            Lista de dicts no formato [{"role": ..., "content": ...}].
+            Lista de dicts no formato ``[{"role": ..., "content": ...}]``.
         """
         return [msg.copy() for msg in self._buffer]

--- a/tests/test_chat_concurrency.py
+++ b/tests/test_chat_concurrency.py
@@ -1,0 +1,55 @@
+"""Testes de concorrência para o cache `_sessions` da rota /chat (TASK-T65)."""
+
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from api.routes.chat import _get_or_create_buffer, _sessions
+from memory.conversation import ConversationBuffer
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions() -> Generator[None, None, None]:
+    """Garante cache vazio antes e depois de cada teste."""
+    _sessions.clear()
+    yield
+    _sessions.clear()
+
+
+def test_concurrent_get_or_create_returns_single_buffer_for_same_session_id() -> None:
+    """50 threads chamando o mesmo session_id resultam em 1 único buffer compartilhado."""
+    session_id = "shared-session"
+
+    with ThreadPoolExecutor(max_workers=50) as executor:
+        buffers: list[ConversationBuffer] = list(
+            executor.map(lambda _: _get_or_create_buffer(session_id), range(50))
+        )
+
+    # Apenas uma entrada em _sessions para esse session_id
+    assert session_id in _sessions
+    assert len(_sessions) == 1
+
+    # Todos os 50 retornos devem ser exatamente o mesmo objeto
+    first = buffers[0]
+    assert all(b is first for b in buffers)
+
+
+def test_concurrent_distinct_session_ids_create_distinct_buffers() -> None:
+    """50 session_ids distintos resultam em 50 entradas separadas."""
+    session_ids = [f"sess-{i}" for i in range(50)]
+
+    with ThreadPoolExecutor(max_workers=50) as executor:
+        buffers = list(executor.map(_get_or_create_buffer, session_ids))
+
+    assert len(_sessions) == 50
+    # Buffers únicos
+    assert len({id(b) for b in buffers}) == 50
+
+
+def test_repeated_call_returns_same_buffer_instance() -> None:
+    """Chamadas sequenciais com o mesmo session_id retornam o mesmo objeto."""
+    session_id = "repeat-session"
+    a = _get_or_create_buffer(session_id)
+    b = _get_or_create_buffer(session_id)
+    assert a is b

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -82,6 +82,31 @@ class TestConversationBuffer(unittest.TestCase):
         self.assertEqual(buffer.to_messages()[0]["content"], "Teste")
         self.assertEqual(len(buffer.to_messages()), 1)
 
+    # ---------------- T65: validação de role/content ----------------
+
+    def test_add_rejects_invalid_role(self):
+        """add() rejeita roles fora de {user, assistant}."""
+        buffer = ConversationBuffer(maxlen=5)
+        with self.assertRaises(ValueError):
+            buffer.add("system", "tentativa de override")
+        with self.assertRaises(ValueError):
+            buffer.add("", "vazio")
+
+    def test_add_rejects_empty_content(self):
+        """add() rejeita content vazio ou só whitespace."""
+        buffer = ConversationBuffer(maxlen=5)
+        with self.assertRaises(ValueError):
+            buffer.add("user", "")
+        with self.assertRaises(ValueError):
+            buffer.add("user", "   \n  ")
+
+    def test_add_accepts_valid_roles(self):
+        """add() aceita 'user' e 'assistant'."""
+        buffer = ConversationBuffer(maxlen=5)
+        buffer.add("user", "ola")
+        buffer.add("assistant", "oi")
+        self.assertEqual(len(buffer.to_messages()), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. Contexto

- **Motivação:** `api/routes/chat.py` mantinha `OrderedDict` `_sessions` sem sincronização. Em FastAPI rodando handler `def` (não-async) no thread pool, duas requisições simultâneas no mesmo `session_id` podiam: (a) ambas verem que a sessão não existe e criar buffers separados, (b) colidir no cleanup de expiry com `KeyError` durante `del`, ou (c) violar invariante do LRU. `ConversationBuffer.add()` aceitava qualquer `role`/`content`, abrindo brecha para corrupção do histórico.
- **Issue:** Resolves #54
- **Task ref.:** TASK-T65

## 2. O que foi feito?

### `api/routes/chat.py`
- [x] `_sessions_lock = threading.Lock()`
- [x] `with _sessions_lock:` envolve cleanup, eviction LRU, lookup e insert
- [x] `del _sessions[sid]` → `.pop(sid, None)` (idempotente, sem KeyError sob race)

### `memory/conversation.py`
- [x] `_VALID_ROLES = frozenset({\"user\", \"assistant\"})`
- [x] `ConversationBuffer.add()` levanta `ValueError` se role fora do set ou content vazio/whitespace-only

### Testes
- [x] `tests/test_conversation.py`: 3 novos testes (invalid role, empty content, valid roles)
- [x] `tests/test_chat_concurrency.py` (novo): 3 testes — `ThreadPoolExecutor(50)` no mesmo `session_id` → 1 buffer único; 50 session_ids distintos → 50 buffers; idempotência sequencial

## 3. Como testar?

```bash
git checkout feat/TASK-T65-sessions-thread-safety
uv sync --extra dev
pytest tests/test_chat_concurrency.py tests/test_conversation.py -v
ruff check . && ruff format --check .
mypy api/ core/ verification/ retrieval/ generation/ memory/ --ignore-missing-imports
```

## 4. Evidências

- `pytest tests/`: **120 passed** (era 114); cobertura **81.84%**
- `ruff` + `mypy` strict: clean

## 5. Checklist de Auto-Revisão

- [x] Auto-revisão executada
- [x] Sem códigos comentados, prints, debug
- [x] PEP 8 + docstrings
- [x] Sem novas dependências (threading stdlib)
- [x] Commits atômicos
- [x] Avaliação pós-implementação (minor) aprovada