### PR TITLE
feat(retrieval): TASK-T66 — qdrant singleton, dim validation, logging

### DIFF
--- a/.claude/registry.md
+++ b/.claude/registry.md
@@ -67,20 +67,21 @@
 | 47 | 2026-05-26 | TASK-T63 | minor | 4 arquivos — database/models.py, database/db.py, tests/test_db.py (novo), README.md | aprovado | Integridade SQLAlchemy: NOT NULL em campos obrigatórios, index em FKs, ondelete=CASCADE + passive_deletes, Boolean em is_hallucinated, DateTime(timezone=True), connect_args timeout=10, PRAGMA foreign_keys=ON via event listener, get_db rollback-on-exception. 11 novos testes (NULL, CASCADE, tz, rollback). 101 testes, cobertura 70.82%. Breaking: schemas legados ficam frouxos — recriar `smartb100_v2.db`. |
 | 48 | 2026-05-26 | TASK-T64 | minor | 4 arquivos — verification/entropy.py, verification/gate.py, core/config.py, tests/test_verification.py (novo) | aprovado | Estabilidade verificação: epsilon 1e-10 em cosseno, logger.warning em missing API key, try/except parcial em samples, resp.get safe access em ollama, validação provider antes de dispatch, gate fallback score=0.5 em falha de entropia, entropy_temperature em Settings (ge=0.0, le=2.0). 13 novos testes. 114 testes, cobertura 81.37%. mypy strict agora limpo em verification/entropy.py (resolve parte da T74). |
 | 49 | 2026-05-26 | TASK-T65 | minor | 4 arquivos — api/routes/chat.py, memory/conversation.py, tests/test_conversation.py, tests/test_chat_concurrency.py (novo) | aprovado | Thread-safety: `_sessions_lock = threading.Lock()` envolve cleanup/eviction/lookup em `_get_or_create_buffer`; `del` → `.pop(sid, None)`. `ConversationBuffer.add()` valida role em `{"user", "assistant"}` e content não-vazio (ValueError). 6 novos testes (validação + 3 de concorrência ThreadPoolExecutor 50 threads). 120 testes, cobertura 81.84%. |
+| 50 | 2026-05-26 | TASK-T66 | minor | 4 arquivos — retrieval/vector_store.py, retrieval/embedder.py, retrieval/ollama_embeddings.py, tests/test_vector_store.py | aprovado | Singleton QdrantClient com double-checked locking + dim validation (768), logger.warning em payload sem `text`, logger em embedder+ollama_embeddings, `assert` substituído por `raise RuntimeError` defensivo. test_vector_store reescrito em pytest (5 testes incl. singleton reuse). 123 testes, cobertura 82.27%. |
 
 ## Estado da Codebase
 
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
-- **Última atualização:** 2026-05-26 (TASK-T65 — thread-safety em /chat _sessions)
+- **Última atualização:** 2026-05-26 (TASK-T66 — singleton QdrantClient + dim validation + logging)
 - **Último responsável:** Assistente (sessão local)
-- **Branch ativa:** feat/TASK-T65-sessions-thread-safety (a partir de main pós-merge T60-T64)
-- **Dependências alteradas recentemente:** passlib[bcrypt], bcrypt (<5), slowapi (T60) — agora em main
-- **Testes passando:** sim — 120 passed, cobertura 81.84% (≥23%); ruff + format + mypy strict em todos críticos ok (verificado 2026-05-26)
-- **Divergências externas pendentes:** PRs #68-#73 todos mergeados em main; T65 local
-- **Última task concluída:** TASK-T65 — thread-safety _sessions + validação ConversationBuffer
-- **Backlog ativo:** 9 tasks pendentes (T66 ativa — singleton QdrantClient + validação dim; T67–T74 enfileiradas)
-- **PRs abertos:** nenhum (#68-#73 mergeados); PR T65 a abrir após push
+- **Branch ativa:** feat/TASK-T66-retrieval-singleton-logging
+- **Dependências alteradas recentemente:** passlib[bcrypt], bcrypt (<5), slowapi (T60) — todas em main
+- **Testes passando:** sim — 123 passed, cobertura 82.27%; ruff + format + mypy strict em todos críticos ok
+- **Divergências externas pendentes:** PR #74 (T65) mergeada em main; T66 local
+- **Última task concluída:** TASK-T66 — Qdrant singleton, dim validation, logging em retrieval
+- **Backlog ativo:** 8 tasks pendentes (T67 ativa — logging estruturado em todos módulos runtime; T68–T74 enfileiradas)
+- **PRs abertos:** nenhum; PR T66 a abrir após push
 
 ## Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,35 +84,6 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T66
-- **Status:** pendente
-- **Modo:** desenvolvimento
-- **Complexidade:** minor
-- **Data de criação:** 2026-05-26
-
-#### Objetivo
-Singleton de `QdrantClient`, validação de dimensão de embedding e logging em `retrieval/` (issue #52).
-
-#### Contexto
-`retrieval/vector_store.py:29` instancia novo `QdrantClient` a cada `search_context()`. Sem validação de dim. `ollama_embeddings.py:55` usa `assert` (removido com `-O`). Sem logging.
-
-#### Escopo Técnico
-- **Arquivos/módulos envolvidos:** `retrieval/vector_store.py`, `retrieval/embedder.py`, `retrieval/ollama_embeddings.py`, `tests/`
-- **Dependências necessárias:** nenhuma
-- **Impacto em funcionalidades existentes:** baixo (singleton compatível com API atual)
-
-#### Critérios de Aceite
-- [ ] Singleton `_qdrant_client` thread-safe com lazy init
-- [ ] Validação `if len(embedding) != 768: raise ValueError(...)` antes da query
-- [ ] `logger.warning()` quando payload vazio ou sem chave `"text"`
-- [ ] `logger = logging.getLogger(__name__)` em todos módulos retrieval
-- [ ] `assert` em `ollama_embeddings.py:55` substituído por `raise RuntimeError`
-- [ ] Testes: 100 chamadas usam mesma instância (mock); dim incorreta levanta ValueError
-- [ ] `pytest`, `ruff`, `mypy` passam
-
-#### Referências
-- Issue: https://github.com/LukeSantossz/sb100_agents/issues/52
-
 ### TASK-T67
 - **Status:** pendente
 - **Modo:** desenvolvimento
@@ -372,6 +343,20 @@ A verificacao atual mostrou que `ruff check .` passa, mas `mypy retrieval/ gener
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (`registry.md`). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T66 — Singleton QdrantClient + dim validation + logging em retrieval ✓
+- **Concluída em:** 2026-05-26
+- **Branch:** feat/TASK-T66-retrieval-singleton-logging
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** `retrieval/vector_store.py`: singleton `_qdrant_client` com double-checked locking (`_qdrant_lock = threading.Lock()`), validação `len(embedding) != 768 → ValueError`, `logger.warning` quando payload sem chave `text` (com payload_keys nos extras). `retrieval/embedder.py`: `logger.debug` em `generate_embedding`. `retrieval/ollama_embeddings.py`: `logger.warning` por tentativa falha; `assert last_exc is not None` substituído por `if last_exc is None: raise RuntimeError(...)`. `tests/test_vector_store.py` reescrito em pytest (singleton reset via autouse fixture; 5 testes: dim correta, dim 10 rejeita, embedding vazio rejeita, text vazio loga warning, singleton reutiliza client). 123 testes (era 120), cobertura 82.27%.
+
+#### Log de Andamento
+
+| Data | Sessão | Ação Realizada | Status ao Final |
+|------|--------|----------------|-----------------|
+| 2026-05-26 | 1 | Reconhecimento (vector_store, embedder, ollama_embeddings, test_vector_store), branch criada | em andamento |
+| 2026-05-26 | 1 | Implementação (singleton, dim validation, warnings, raise RuntimeError), tests rewrite, validações OK | concluída |
 
 ### TASK-T65 — Thread-safety em /chat _sessions + validação ConversationBuffer ✓
 - **Concluída em:** 2026-05-26

--- a/retrieval/embedder.py
+++ b/retrieval/embedder.py
@@ -4,8 +4,12 @@ Utiliza o modelo configurado em settings.embed_model (default: nomic-embed-text)
 para converter texto em vetores densos de 768 dimensões.
 """
 
+import logging
+
 from core.config import settings
 from retrieval.ollama_embeddings import embed_text
+
+logger = logging.getLogger(__name__)
 
 
 def generate_embedding(text: str) -> list[float]:
@@ -23,4 +27,5 @@ def generate_embedding(text: str) -> list[float]:
     Raises:
         Exception: Última falha retornada pelo Ollama após esgotar retries (ex.: modelo ausente).
     """
+    logger.debug("embedder.generate", extra={"chars": len(text)})
     return embed_text(settings.embed_model, text)

--- a/retrieval/ollama_embeddings.py
+++ b/retrieval/ollama_embeddings.py
@@ -6,11 +6,14 @@ sob carga; retries com backoff reduzem falhas intermitentes na indexação e no 
 
 from __future__ import annotations
 
+import logging
 import time
 
 import httpx
 import ollama
 from ollama import RequestError, ResponseError
+
+logger = logging.getLogger(__name__)
 
 # Limite conservador para o contexto do modelo de embedding (caracteres).
 _MAX_EMBED_CHARS = 8192
@@ -48,9 +51,15 @@ def embed_text(model: str, prompt: str) -> list[float]:
             OSError,
         ) as exc:
             last_exc = exc
+            logger.warning(
+                "ollama_embeddings.attempt_failed",
+                extra={"attempt": attempt, "error": str(exc)},
+            )
             if attempt >= _MAX_RETRIES - 1:
                 break
             delay = min(_RETRY_BASE_SEC * (2**attempt), _RETRY_MAX_SEC)
             time.sleep(delay)
-    assert last_exc is not None
+    if last_exc is None:
+        # Defensivo: o loop só sai sem exceção se retornar com sucesso.
+        raise RuntimeError("embed_text exhausted retries with no captured exception")
     raise last_exc

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -2,11 +2,40 @@
 
 Recupera chunks de texto semanticamente similares à query usando
 busca por vizinhos mais próximos (ANN) no Qdrant.
+
+TASK-T66: usa singleton thread-safe do ``QdrantClient`` (evita instanciar
+TCP/HTTP a cada query) e valida a dimensão do embedding antes da chamada.
 """
+
+import logging
+import threading
 
 from qdrant_client import QdrantClient
 
 from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_EMBEDDING_DIM = 768
+
+_qdrant_client: QdrantClient | None = None
+_qdrant_lock = threading.Lock()
+
+
+def _get_client() -> QdrantClient:
+    """Retorna instância singleton do ``QdrantClient`` (lazy init thread-safe).
+
+    Implementa double-checked locking para minimizar contenção após o primeiro
+    acesso. Reset (para testes) deve zerar o módulo-level ``_qdrant_client``.
+    """
+    global _qdrant_client
+    if _qdrant_client is None:
+        with _qdrant_lock:
+            if _qdrant_client is None:
+                _qdrant_client = QdrantClient(
+                    url=settings.qdrant_url, api_key=settings.qdrant_api_key
+                )
+    return _qdrant_client
 
 
 def search_context(embedding: list[float]) -> list[str]:
@@ -23,14 +52,31 @@ def search_context(embedding: list[float]) -> list[str]:
         Retorna lista vazia se nenhum resultado for encontrado.
 
     Raises:
+        ValueError: Se o embedding não tiver exatamente 768 dimensões.
         qdrant_client.http.exceptions.UnexpectedResponse: Se a coleção não existir.
         requests.exceptions.ConnectionError: Se o Qdrant estiver offline.
     """
-    client = QdrantClient(url=settings.qdrant_url, api_key=settings.qdrant_api_key)
+    if len(embedding) != _EMBEDDING_DIM:
+        raise ValueError(f"embedding must have {_EMBEDDING_DIM} dimensions; got {len(embedding)}")
+
+    client = _get_client()
     resultados = client.query_points(
         collection_name=settings.collection_name,
         query=embedding,
         limit=settings.top_k,
         with_payload=True,
     ).points
-    return [str((r.payload or {}).get("text") or "") for r in resultados]
+
+    chunks: list[str] = []
+    for point in resultados:
+        payload = point.payload or {}
+        text = payload.get("text")
+        if not text:
+            logger.warning(
+                "vector_store.empty_or_missing_text",
+                extra={"payload_keys": sorted(payload.keys())},
+            )
+            chunks.append("")
+        else:
+            chunks.append(str(text))
+    return chunks

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,51 +1,82 @@
-import unittest
+"""Testes do retrieval/vector_store (TASK-T66 — singleton + dim validation + warnings)."""
+
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from core.config import settings
+from retrieval import vector_store as vs_module
 from retrieval.vector_store import search_context
 
 
-class TestSearchContext(unittest.TestCase):
-    @patch("retrieval.vector_store.QdrantClient")
-    def test_returns_list_str_with_top_k_elements(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> Generator[None, None, None]:
+    """Reseta o singleton entre testes para isolar mocks de ``QdrantClient``."""
+    vs_module._qdrant_client = None
+    yield
+    vs_module._qdrant_client = None
 
-        points = []
-        for i in range(settings.top_k):
-            p = MagicMock()
-            p.payload = {"text": f"chunk-{i}"}
-            points.append(p)
+
+def _make_point(text: str | None = "chunk") -> MagicMock:
+    point = MagicMock()
+    point.payload = {"text": text} if text is not None else {}
+    return point
+
+
+def test_search_returns_text_list_with_top_k_chunks() -> None:
+    with patch("retrieval.vector_store.QdrantClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        points = [_make_point(f"chunk-{i}") for i in range(settings.top_k)]
         mock_client.query_points.return_value = MagicMock(points=points)
 
-        embedding = [0.1] * 768
-        out = search_context(embedding)
+        out = search_context([0.1] * 768)
 
-        self.assertIsInstance(out, list)
-        self.assertEqual(len(out), settings.top_k)
-        self.assertEqual(out, [f"chunk-{i}" for i in range(settings.top_k)])
+        assert out == [f"chunk-{i}" for i in range(settings.top_k)]
         mock_client.query_points.assert_called_once_with(
             collection_name=settings.collection_name,
-            query=embedding,
+            query=[0.1] * 768,
             limit=settings.top_k,
             with_payload=True,
         )
-        mock_client_cls.assert_called_once_with(
-            url=settings.qdrant_url, api_key=settings.qdrant_api_key
-        )
 
-    @patch("retrieval.vector_store.QdrantClient")
-    def test_missing_text_payload_returns_empty_string(self, mock_client_cls):
+
+def test_search_rejects_wrong_dim() -> None:
+    with pytest.raises(ValueError, match="must have 768 dimensions"):
+        search_context([0.1] * 10)
+
+
+def test_search_rejects_empty_embedding() -> None:
+    with pytest.raises(ValueError, match="must have 768 dimensions"):
+        search_context([])
+
+
+def test_missing_text_logs_warning_and_returns_empty_string(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        patch("retrieval.vector_store.QdrantClient") as mock_cls,
+        caplog.at_level("WARNING", logger="retrieval.vector_store"),
+    ):
         mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
-        p = MagicMock()
-        p.payload = {}
-        mock_client.query_points.return_value = MagicMock(points=[p])
+        mock_cls.return_value = mock_client
+        mock_client.query_points.return_value = MagicMock(points=[_make_point(None)])
 
-        out = search_context([0.0])
+        out = search_context([0.1] * 768)
 
-        self.assertEqual(out, [""])
+    assert out == [""]
+    assert any("empty_or_missing_text" in record.message for record in caplog.records)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_singleton_reuses_client_across_calls() -> None:
+    with patch("retrieval.vector_store.QdrantClient") as mock_cls:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.query_points.return_value = MagicMock(points=[])
+
+        for _ in range(5):
+            search_context([0.1] * 768)
+
+        # Apenas 1 instanciação apesar de 5 chamadas
+        mock_cls.assert_called_once_with(url=settings.qdrant_url, api_key=settings.qdrant_api_key)


### PR DESCRIPTION
## 1. Contexto

- **Motivação:** `retrieval/vector_store.py` instanciava `QdrantClient` a cada `search_context()` (TCP/HTTP overhead recorrente). Sem validação de dimensão antes da query (Qdrant retorna erro genérico se dim != 768). `retrieval/ollama_embeddings.py:55` usava `assert` que pode ser removido com `python -O`. Sem `logger` em nenhum módulo retrieval.
- **Issue:** Resolves #52
- **Task ref.:** TASK-T66

## 2. O que foi feito?

- [x] `retrieval/vector_store.py`: singleton `_qdrant_client` com double-checked locking via `_qdrant_lock`
- [x] Validação `len(embedding) != 768` → `ValueError` antes da query
- [x] `logger.warning` quando payload retorna sem chave `text` (com `payload_keys` no extra)
- [x] `logger = logging.getLogger(__name__)` em `vector_store`, `embedder`, `ollama_embeddings`
- [x] `assert last_exc is not None` substituído por `if last_exc is None: raise RuntimeError(...)`
- [x] `tests/test_vector_store.py` reescrito em pytest (5 testes: top_k, dim incorreta, payload empty, singleton reuse com 5 chamadas → 1 instanciação)

## 3. Como testar?

```bash
git checkout feat/TASK-T66-retrieval-singleton-logging
uv sync --extra dev
pytest tests/test_vector_store.py -v
ruff check . && ruff format --check .
mypy api/ core/ verification/ retrieval/ generation/ memory/ --ignore-missing-imports
```

## 4. Evidências

- `pytest tests/`: **123 passed** (era 120); cobertura **82.27%**
- `ruff` + `mypy` strict: clean

## 5. Checklist

- [x] Auto-revisão
- [x] Sem prints/debug
- [x] PEP 8 + docstrings
- [x] Sem deps novas
- [x] Commits atômicos
- [x] Avaliação minor aprovada