### PR TITLE
refactor: TASK-T76 — consolidate ollama clients + coverage gaps from T75

### DIFF
--- a/.claude/registry.md
+++ b/.claude/registry.md
@@ -36,20 +36,21 @@
 | 52 | 2026-05-26 | TASK-T68 | minor | 5 arquivos — core/config.py, generation/llm.py, verification/entropy.py, tests/test_llm.py, tests/test_verification.py | aprovado | Ollama Client com timeout (`ollama_timeout` settings, default 120s, bounds 1-600); wrapper `_ollama_chat` testável; error handling em `generate` (RequestError/ResponseError/TimeoutError/ConnectionError); singleton thread-safe `_ollama_client`. Cache local de embeddings em `_cluster_responses` reduz embed calls de O(N²) para O(N único). Tests refatorados (7 mocks atualizados + 2 timeouts + 1 cache). 126 testes, cobertura 84.80%. |
 | 53 | 2026-05-26 | TASK-T69 | major | 3 arquivos — tests/test_vector_store.py, tests/test_embedder.py, tests/test_integration.py | aprovado | Robustez de testes: `ScoredPoint` real (não MagicMock) em test_vector_store; 3 edge cases em test_embedder (string vazia/longa/Unicode); autouse fixture `_clear_sessions_cache` em test_integration evita leak entre testes. Coverage critério ≥50% alcançado: **84.80%**. Critérios de verification e Ollama already cobertos por T64+T68. 129 testes, cobertura 84.80%. |
 | 54 | 2026-05-26 | TASK-T75 | minor | 4 arquivos — .claude/registry-archive.md (novo), .claude/registry.md, retrieval/ollama_embeddings.py, api/routes/chat.py | aprovado | Correções pós-review T60-T69: arquivamento regra 08.5 (entradas #1-#38 → archive; 15 ativas restantes); ollama_embeddings com `Client(timeout=5.0)` + retries reduzidos para 4 (worst-case ~25s, era indeterminado); logger.info `chat.access` + warnings nos paths 503. Padrões Recorrentes ampliados com push sem autorização, arquivamento esquecido e checklist agêntico ausente. 129 testes, cobertura 83.23%. |
+| 55 | 2026-05-26 | TASK-T76 | minor | 7 arquivos — core/ollama_clients.py (novo), core/config.py, generation/llm.py, verification/entropy.py, retrieval/ollama_embeddings.py, tests/test_ollama_clients.py (novo), tests/test_verification.py, tests/test_integration.py | aprovado | Consolida 3 padrões de cliente Ollama em módulo único `core/ollama_clients.py` (singletons thread-safe). `settings.ollama_embed_timeout` substitui hardcode. Critério "nenhum `ollama.Client(...)` fora de core" verificado por grep. 7 novos testes (6 cobrindo singletons/timeouts/reset/independência + 1 caplog para chat.access). 136 testes, cobertura 85.87%. Wiki externa consultada (correção comportamental #1 do review T75). |
 
 ## Estado da Codebase
 
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
-- **Última atualização:** 2026-05-26 (TASK-T75 — correções pós-review)
+- **Última atualização:** 2026-05-26 (TASK-T76 — consolidação de clientes Ollama)
 - **Último responsável:** Assistente (sessão local)
-- **Branch ativa:** chore/TASK-T75-post-review-fixes
+- **Branch ativa:** refactor/TASK-T76-ollama-client-consolidation
 - **Dependências alteradas recentemente:** nenhuma desde T60 — todas em main
-- **Testes passando:** sim — 129 passed, cobertura 83.23%; ruff + format + mypy strict em todos críticos ok
-- **Divergências externas pendentes:** PRs #74-#78 mergeadas em main; T75 local
-- **Última task concluída:** TASK-T75 — arquivamento de registry, timeout reduzido em ollama_embeddings, logging de acesso em /chat
+- **Testes passando:** sim — 136 passed, cobertura 85.87%; ruff + format + mypy strict em todos críticos ok
+- **Divergências externas pendentes:** PRs #74-#79 mergeadas em main; T76 local
+- **Última task concluída:** TASK-T76 — `core/ollama_clients.py` centralizado, 3 consumers consolidados, 7 testes
 - **Backlog ativo:** 5 tasks pendentes (T70 ativa — hardening eval pipeline; T71–T74 enfileiradas)
-- **PRs abertos:** nenhum; PR T75 a abrir após push
+- **PRs abertos:** nenhum; PR T76 a abrir após push (com autorização)
 
 ## Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -247,6 +247,20 @@ A verificacao atual mostrou que `ruff check .` passa, mas `mypy retrieval/ gener
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (`registry.md`). Nunca remova entradas — o histórico é cumulativo.
 
+### TASK-T76 — Consolidação de clientes Ollama + cobertura dos gaps T75 ✓
+- **Concluída em:** 2026-05-26
+- **Branch:** refactor/TASK-T76-ollama-client-consolidation
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** Endereça os 3 itens de débito técnico do review pós-T75. (1) `core/ollama_clients.py` (novo) com `get_chat_client()` e `get_embed_client()` thread-safe (DCL); helper `reset_clients()` para testes. (2) `settings.ollama_embed_timeout: float = Field(default=5.0, ge=1.0, le=120.0)` substitui o hardcode `_EMBED_HTTP_TIMEOUT`. (3) Consumers refatorados: `generation/llm.py` (remove singleton local), `verification/entropy.py` (não-singleton vira singleton compartilhado), `retrieval/ollama_embeddings.py` (singleton local removido). 6 novos testes em `tests/test_ollama_clients.py` (singleton chat, singleton embed, timeouts, reset, independência); patch ajustado em `tests/test_verification.py` (passa a mockar `get_chat_client`); 1 teste de `caplog` em `tests/test_integration.py` validando emissão de `chat.access` com username + session_id. Critério "nenhum `ollama.Client(...)` fora de `core/ollama_clients.py`" verificado por grep. 136 testes (era 129; +7), cobertura 85.87% (era 83.23%; +2.64 pp). Wiki externa consultada (correção comportamental #1 do review T75): `ollama.md` cobre setup mas sem pattern de connection pool catalogado, decisão arquitetural própria.
+
+#### Log de Andamento
+
+| Data | Sessão | Ação Realizada | Status ao Final |
+|------|--------|----------------|-----------------|
+| 2026-05-26 | 1 | Wiki externa consultada (ollama.md, tema-deploy-llm.md); reconhecimento dos 3 sites de cliente; T76 registrada com critérios verificáveis | em andamento |
+| 2026-05-26 | 1 | Implementação por etapas (core module, settings, 3 consumers, 7 testes); 8/8 critérios cumpridos no auto-review | concluída |
+
 ### TASK-T75 — Correções pós-review (arquivamento, ollama timeout, /chat logging) ✓
 - **Concluída em:** 2026-05-26
 - **Branch:** chore/TASK-T75-post-review-fixes

--- a/core/config.py
+++ b/core/config.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
     entropy_num_samples: int = Field(default=2, ge=2)
     entropy_temperature: float = Field(default=0.7, ge=0.0, le=2.0)
     ollama_timeout: float = Field(default=120.0, ge=1.0, le=600.0)
+    ollama_embed_timeout: float = Field(default=5.0, ge=1.0, le=120.0)
     groq_api_key: str | None = None
     openrouter_api_key: str | None = None
     jwt_secret_key: str = ""

--- a/core/ollama_clients.py
+++ b/core/ollama_clients.py
@@ -1,0 +1,68 @@
+"""Clientes Ollama compartilhados (TASK-T76).
+
+Consolida em um único módulo o padrão de cliente HTTP Ollama com timeout, que
+antes existia em três variantes inconsistentes (em ``generation/llm.py``,
+``verification/entropy.py`` e ``retrieval/ollama_embeddings.py``).
+
+Expõe dois singletons thread-safe via double-checked locking:
+
+- :func:`get_chat_client` — para geração de respostas; timeout configurável via
+  ``settings.ollama_timeout`` (default 120s).
+- :func:`get_embed_client` — para embeddings; timeout configurável via
+  ``settings.ollama_embed_timeout`` (default 5s, mais agressivo porque embed
+  é leve e parte do hot-path do RAG).
+
+Testes que dependem de mocks do ``ollama.Client`` devem chamar
+:func:`reset_clients` em fixture autouse para isolar o estado entre cenários.
+"""
+
+import threading
+
+from ollama import Client as OllamaClient
+
+from core.config import settings
+
+_chat_client: OllamaClient | None = None
+_chat_client_lock = threading.Lock()
+
+_embed_client: OllamaClient | None = None
+_embed_client_lock = threading.Lock()
+
+
+def get_chat_client() -> OllamaClient:
+    """Retorna o singleton do cliente Ollama para chat completions.
+
+    Usa ``settings.ollama_timeout`` como timeout HTTP. Lazy init thread-safe.
+    """
+    global _chat_client
+    if _chat_client is None:
+        with _chat_client_lock:
+            if _chat_client is None:
+                _chat_client = OllamaClient(timeout=settings.ollama_timeout)
+    return _chat_client
+
+
+def get_embed_client() -> OllamaClient:
+    """Retorna o singleton do cliente Ollama para embeddings.
+
+    Usa ``settings.ollama_embed_timeout`` como timeout HTTP. Lazy init thread-safe.
+    """
+    global _embed_client
+    if _embed_client is None:
+        with _embed_client_lock:
+            if _embed_client is None:
+                _embed_client = OllamaClient(timeout=settings.ollama_embed_timeout)
+    return _embed_client
+
+
+def reset_clients() -> None:
+    """Limpa os singletons (chat e embed).
+
+    Uso esperado: fixture autouse em testes que precisem patchar ``OllamaClient``
+    e garantir que a próxima chamada instancie a partir do mock.
+    """
+    global _chat_client, _embed_client
+    with _chat_client_lock:
+        _chat_client = None
+    with _embed_client_lock:
+        _embed_client = None

--- a/generation/llm.py
+++ b/generation/llm.py
@@ -9,41 +9,26 @@ Inclui mitigações contra prompt injection (TASK-T61):
 
 import logging
 import re
-import threading
 import time
 
 import ollama
-from ollama import Client as OllamaClient
 
 from core.config import settings
+from core.ollama_clients import get_chat_client
 from core.schemas import ExpertiseLevel, UserProfile
 
 logger = logging.getLogger(__name__)
-
-_ollama_client: OllamaClient | None = None
-_ollama_client_lock = threading.Lock()
-
-
-def _get_ollama_client() -> OllamaClient:
-    """Singleton thread-safe do Ollama Client com timeout configurado.
-
-    O cliente reusa a conexão HTTP entre chamadas e aplica
-    ``settings.ollama_timeout`` (default 120s) — sem isso, o handler bloqueia
-    indefinidamente se o servidor Ollama estiver indisponível.
-    """
-    global _ollama_client
-    if _ollama_client is None:
-        with _ollama_client_lock:
-            if _ollama_client is None:
-                _ollama_client = OllamaClient(timeout=settings.ollama_timeout)
-    return _ollama_client
 
 
 def _ollama_chat(
     model: str, messages: list[dict[str, str]], options: dict[str, int]
 ) -> dict[str, dict[str, str]]:
-    """Wrapper testável para ``ollama.Client.chat`` com timeout aplicado."""
-    return _get_ollama_client().chat(  # type: ignore[return-value]
+    """Wrapper testável para ``ollama.Client.chat`` com timeout aplicado.
+
+    O cliente compartilhado vem de :func:`core.ollama_clients.get_chat_client`,
+    que aplica ``settings.ollama_timeout`` e reusa a conexão HTTP.
+    """
+    return get_chat_client().chat(  # type: ignore[return-value]
         model=model, messages=messages, options=options
     )
 

--- a/retrieval/ollama_embeddings.py
+++ b/retrieval/ollama_embeddings.py
@@ -3,30 +3,21 @@
 O servidor local do Ollama no Windows pode retornar 500 ou derrubar a conexão
 sob carga; retries com backoff reduzem falhas intermitentes na indexação e no RAG.
 
-TASK-T75 (follow-up T68): orçamento total de timeout endurecido para ≤30s.
-Antes: 6 tentativas com sleeps capeados em 60s e sem timeout HTTP — chamadas
-podiam ficar penduradas indefinidamente se o Ollama hang.
-
-Configuração atual (worst-case ~25s):
-    - ``_EMBED_HTTP_TIMEOUT`` = 5.0s por chamada (via ``ollama.Client(timeout=...)``)
-    - ``_MAX_RETRIES`` = 4 tentativas (era 6)
-    - ``_RETRY_MAX_SEC`` = 2.0s (capeia o backoff exponencial — era 60.0)
-
-Trade-off: a retração agressiva falha mais cedo se o servidor Ollama estiver
-overloaded ou em cold-start de modelo (~10s típico). Em ambientes de produção
-com cold-load esperado, considerar aumentar ``_EMBED_HTTP_TIMEOUT`` ou
-``_MAX_RETRIES`` via configuração — atualmente são constantes de módulo.
+TASK-T76 (consolidação): cliente HTTP centralizado em
+:mod:`core.ollama_clients`. Timeout HTTP vem de ``settings.ollama_embed_timeout``
+(default 5s, ajustável). Worst-case do orçamento total permanece em ~25s
+(4 tentativas × 5s + sleeps 0.75/1.5/2.0).
 """
 
 from __future__ import annotations
 
 import logging
-import threading
 import time
 
 import httpx
-import ollama
 from ollama import RequestError, ResponseError
+
+from core.ollama_clients import get_embed_client
 
 logger = logging.getLogger(__name__)
 
@@ -35,20 +26,6 @@ _MAX_EMBED_CHARS = 8192
 _MAX_RETRIES = 4
 _RETRY_BASE_SEC = 0.75
 _RETRY_MAX_SEC = 2.0
-_EMBED_HTTP_TIMEOUT = 5.0
-
-_embed_client: ollama.Client | None = None
-_embed_client_lock = threading.Lock()
-
-
-def _get_embed_client() -> ollama.Client:
-    """Singleton thread-safe do cliente Ollama para embeddings (com timeout)."""
-    global _embed_client
-    if _embed_client is None:
-        with _embed_client_lock:
-            if _embed_client is None:
-                _embed_client = ollama.Client(timeout=_EMBED_HTTP_TIMEOUT)
-    return _embed_client
 
 
 def embed_text(model: str, prompt: str) -> list[float]:
@@ -65,7 +42,7 @@ def embed_text(model: str, prompt: str) -> list[float]:
         A última exceção após esgotar as tentativas, se todas falharem.
     """
     text = (prompt or "")[:_MAX_EMBED_CHARS]
-    client = _get_embed_client()
+    client = get_embed_client()
     last_exc: BaseException | None = None
     for attempt in range(_MAX_RETRIES):
         try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -265,3 +265,30 @@ def test_nominal_flow_no_500_errors(
         response = client.post("/chat", json=payload)
         assert response.status_code != 500, f"HTTP 500 em payload: {payload}"
         assert response.status_code == 200
+
+
+def test_chat_access_log_emits_username_and_session_id(
+    client,
+    mock_embedding,
+    mock_context,
+    mock_verification_disabled,
+    mock_generate_by_expertise,
+    caplog: pytest.LogCaptureFixture,
+):
+    """TASK-T76: handler de /chat emite log estruturado com username + session_id."""
+    payload = {
+        "session_id": "log-session-42",
+        "question": "ping",
+        "profile": {"name": "TestUser", "expertise": "beginner"},
+    }
+
+    with caplog.at_level("INFO", logger="api.routes.chat"):
+        response = client.post("/chat", json=payload)
+
+    assert response.status_code == 200
+    access_records = [r for r in caplog.records if "chat.access" in r.message]
+    assert len(access_records) >= 1
+    # Verifica fields estruturados (do `extra=` kwarg do logger.info)
+    record = access_records[0]
+    assert getattr(record, "username", None) == "testuser"
+    assert getattr(record, "session_id", None) == "log-session-42"

--- a/tests/test_ollama_clients.py
+++ b/tests/test_ollama_clients.py
@@ -1,0 +1,98 @@
+"""Testes do core.ollama_clients (TASK-T76).
+
+Cobre singletons thread-safe, propagação de timeout das Settings e reset.
+"""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from core import ollama_clients
+from core.config import settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons() -> Generator[None, None, None]:
+    """Garante estado limpo antes e depois de cada teste."""
+    ollama_clients.reset_clients()
+    yield
+    ollama_clients.reset_clients()
+
+
+def test_get_chat_client_returns_singleton() -> None:
+    with patch("core.ollama_clients.OllamaClient") as mock_cls:
+        sentinel = object()
+        mock_cls.return_value = sentinel
+
+        first = ollama_clients.get_chat_client()
+        second = ollama_clients.get_chat_client()
+
+        assert first is sentinel
+        assert first is second
+        mock_cls.assert_called_once_with(timeout=settings.ollama_timeout)
+
+
+def test_get_embed_client_returns_singleton() -> None:
+    with patch("core.ollama_clients.OllamaClient") as mock_cls:
+        sentinel = object()
+        mock_cls.return_value = sentinel
+
+        first = ollama_clients.get_embed_client()
+        second = ollama_clients.get_embed_client()
+
+        assert first is sentinel
+        assert first is second
+        mock_cls.assert_called_once_with(timeout=settings.ollama_embed_timeout)
+
+
+def test_chat_client_uses_settings_ollama_timeout() -> None:
+    with patch("core.ollama_clients.OllamaClient") as mock_cls:
+        mock_cls.return_value = object()
+        ollama_clients.get_chat_client()
+
+        _, kwargs = mock_cls.call_args
+        assert kwargs["timeout"] == settings.ollama_timeout
+
+
+def test_embed_client_uses_settings_ollama_embed_timeout() -> None:
+    with patch("core.ollama_clients.OllamaClient") as mock_cls:
+        mock_cls.return_value = object()
+        ollama_clients.get_embed_client()
+
+        _, kwargs = mock_cls.call_args
+        assert kwargs["timeout"] == settings.ollama_embed_timeout
+
+
+def test_reset_clients_forces_reinstantiation() -> None:
+    with patch("core.ollama_clients.OllamaClient") as mock_cls:
+        mock_cls.return_value = object()
+
+        ollama_clients.get_chat_client()
+        ollama_clients.get_embed_client()
+        # 2 chamadas (chat + embed) já feitas
+        assert mock_cls.call_count == 2
+
+        ollama_clients.reset_clients()
+
+        ollama_clients.get_chat_client()
+        # Após reset, chat foi instanciado novamente → +1
+        assert mock_cls.call_count == 3
+
+
+def test_chat_and_embed_clients_are_independent() -> None:
+    with patch("core.ollama_clients.OllamaClient") as mock_cls:
+        # Cada chamada à classe retorna um objeto diferente
+        instances = [object(), object()]
+        mock_cls.side_effect = instances
+
+        chat_inst = ollama_clients.get_chat_client()
+        embed_inst = ollama_clients.get_embed_client()
+
+        assert chat_inst is not embed_inst
+        # Chamadas distintas para chat e embed, cada uma com seu timeout
+        assert mock_cls.call_count == 2
+        chat_call_kwargs = mock_cls.call_args_list[0].kwargs
+        embed_call_kwargs = mock_cls.call_args_list[1].kwargs
+        assert chat_call_kwargs["timeout"] == settings.ollama_timeout
+        assert embed_call_kwargs["timeout"] == settings.ollama_embed_timeout

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -131,12 +131,16 @@ def test_generate_samples_propagates_when_all_fail() -> None:
 
 
 def _patch_ollama_client(response: dict[str, Any]) -> Any:
-    """Patcha ``ollama.Client`` para retornar um mock cujo ``chat`` devolve ``response``."""
+    """Patcha ``get_chat_client`` para retornar um mock cujo ``chat`` devolve ``response``.
+
+    Após TASK-T76, ``_generate_one_ollama`` consome o singleton centralizado em
+    :mod:`core.ollama_clients`; o mock vai direto na função de acesso.
+    """
     from unittest.mock import MagicMock
 
     fake = MagicMock()
     fake.chat.return_value = response
-    return patch.object(entropy_module.ollama, "Client", return_value=fake)
+    return patch.object(entropy_module, "get_chat_client", return_value=fake)
 
 
 def test_generate_one_ollama_handles_missing_message_key() -> None:

--- a/verification/entropy.py
+++ b/verification/entropy.py
@@ -17,9 +17,8 @@ import logging
 import math
 from typing import Any, cast
 
-import ollama
-
 from core.config import settings
+from core.ollama_clients import get_chat_client
 from retrieval.ollama_embeddings import embed_text
 
 logger = logging.getLogger(__name__)
@@ -63,11 +62,10 @@ def _generate_one_groq(question: str, context: str, model: str) -> str:
 def _generate_one_ollama(question: str, context: str, model: str) -> str:
     # ollama-py retorna ChatResponse; cast para dict[str, Any] mantém o acesso
     # seguro via ``.get`` (que continua válido em runtime para ChatResponse).
-    # Client com timeout explícito evita hang indefinido se o servidor Ollama estiver indisponível.
-    client = ollama.Client(timeout=settings.ollama_timeout)
+    # Cliente compartilhado (singleton com timeout — ver core/ollama_clients).
     resp = cast(
         dict[str, Any],
-        client.chat(
+        get_chat_client().chat(
             model=model,
             messages=_build_messages(question, context),
             options={


### PR DESCRIPTION
## 1. Contexto

- **Motivação:** Review pós-T75 (Modo Review formal) identificou 3 itens de débito técnico:
  1. **Inconsistência arquitetural** — 3 padrões de cliente Ollama coexistindo (`generation/llm._ollama_client` singleton, `verification/entropy._generate_one_ollama` não-singleton, `retrieval/ollama_embeddings._embed_client` singleton com timeout hardcoded).
  2. **Hardcode em vez de Settings** — `_EMBED_HTTP_TIMEOUT = 5.0` violando padrão de configurabilidade estabelecido em T62.
  3. **Cobertura ausente** — singleton de embed, timeout aplicado e `logger.info(\"chat.access\")` da T75 sem testes específicos.
- **Task ref.:** TASK-T76 (`.claude/tasks.md`)

> Não há issue GitHub correspondente — débito identificado em review interno.

## 2. O que foi feito?

### `core/ollama_clients.py` (novo, 65 linhas)
- [x] `get_chat_client()` — singleton thread-safe (DCL), usa `settings.ollama_timeout`
- [x] `get_embed_client()` — singleton thread-safe (DCL), usa `settings.ollama_embed_timeout`
- [x] `reset_clients()` — helper para fixtures autouse de teste

### `core/config.py`
- [x] `ollama_embed_timeout: float = Field(default=5.0, ge=1.0, le=120.0)` adicionado

### Consumers refatorados (3 arquivos)
- [x] `generation/llm.py` — `_ollama_client`/`_get_ollama_client` removidos; `_ollama_chat` agora delega a `get_chat_client()`
- [x] `verification/entropy.py` — `_generate_one_ollama` deixou de criar cliente por chamada; usa `get_chat_client()`; `import ollama` desnecessário removido
- [x] `retrieval/ollama_embeddings.py` — `_EMBED_HTTP_TIMEOUT`/`_embed_client`/`_embed_client_lock`/`_get_embed_client` removidos; usa `get_embed_client()`

### Testes (3 arquivos)
- [x] `tests/test_ollama_clients.py` (novo) — 6 testes: singleton chat, singleton embed, timeout chat, timeout embed, reset, independência entre clientes
- [x] `tests/test_verification.py` — `_patch_ollama_client` agora mocka `entropy_module.get_chat_client`
- [x] `tests/test_integration.py` — `test_chat_access_log_emits_username_and_session_id` valida emissão de `chat.access` via `caplog` com campos `username` + `session_id`

### Critério verificável
- [x] `grep -rn 'ollama\.Client\|OllamaClient' --include='*.py' .` retorna **apenas** matches em `core/ollama_clients.py` (runtime) — verificado durante implementação

## 3. Como testar?

```bash
git checkout refactor/TASK-T76-ollama-client-consolidation
uv sync --extra dev
pytest tests/test_ollama_clients.py tests/test_integration.py::test_chat_access_log_emits_username_and_session_id -v
ruff check . && ruff format --check .
mypy api/ core/ verification/ retrieval/ generation/ memory/ --ignore-missing-imports
```

Verificação manual:
```bash
# Confirma o critério de DRY
grep -rn "OllamaClient\|ollama\.Client" --include="*.py" . | grep -v ".venv" | grep -v "test_"
# Deve listar apenas core/ollama_clients.py
```

## 4. Evidências

- `pytest tests/`: **136 passed** (era 129; +7)
- Cobertura: **85.87%** (era 83.23%; +2.64 pp)
- `ruff check .` + `ruff format --check .`: clean
- `mypy` strict em `api/ core/ verification/ retrieval/ generation/ memory/`: clean (22 source files)

## 5. Checklist de Auto-Revisão (regra 06.1 base)

- [x] Auto-revisão executada na aba "Files Changed"
- [x] Sem códigos comentados, prints ou logs de debug
- [x] PEP 8 + docstrings Google Style + type hints
- [x] Sem novas dependências (só rearranjo)
- [x] Nomenclatura: snake_case Python; constantes em UPPER_CASE
- [x] 4 commits atômicos: `refactor(core)`, `refactor(runtime)`, `test(ollama)`, `docs(tasks)`
- [x] Avaliação pós-implementação executada e 8/8 critérios cumpridos

## 6. Checklist Estendido — Código Gerado por Agente (regra 06.1)

- [x] **Todo diff revisado** — cada Edit comparado ao contexto de leitura prévia; sem aceite cego
- [x] **Agente consegue explicar cada módulo alterado** — descrição em §2 acima
- [x] **Sem coerência superficial** — refactor preserva comportamento runtime (mesmos timeouts, mesma semântica de retries); novo teste de caplog garante log estruturado funcionando ponta-a-ponta
- [x] **Sem abstração excessiva** — `core/ollama_clients.py` tem 2 funções públicas + 1 reset; nada genérico/configurável além do necessário; mesmo padrão DCL já estabelecido por T66/T68
- [x] **Sem tratamento decorativo de erros** — nenhum try/except adicionado; comportamento de retries em `embed_text` preservado
- [x] **Sem dependências fantasma** — todos os imports são `threading` (stdlib), `ollama.Client` (já no projeto), `settings` (core)
- [x] **Sem código plausível mas inventado** — API `ollama.Client(timeout=...)` mesma que T68 usou; campos `extra=` do logger.info verificados via `caplog.records[0].username/session_id`
- [x] **Sem repetição disfarçada** — eliminou as 3 implementações duplicadas; nenhum padrão DRY restante

## 7. Processo

Esta task aplicou as 4 correções comportamentais do review pós-T75:
- ✓ Wiki externa consultada antes de decidir arquitetura (`ollama.md`, `tema-deploy-llm.md` — sem pattern catalogado; decisão própria registrada)
- ✓ Checklist agêntico no PR body (esta seção)
- ✓ Autorização explícita pedida ao usuário antes de `git push`/`gh pr create`/`gh pr merge`
- ✓ Checkpoints emitidos antes de cada bloco de write (5 ao total)

Resolves: itens 2, 3 e 4 do review pós-T75.