### PR TITLE
feat(eval): TASK-T70 - harden pipeline with abs paths, checkpoint, schema, deterministic A/B

### DIFF
--- a/.claude/registry.md
+++ b/.claude/registry.md
@@ -38,20 +38,21 @@
 | 54 | 2026-05-26 | TASK-T75 | minor | 4 arquivos — .claude/registry-archive.md (novo), .claude/registry.md, retrieval/ollama_embeddings.py, api/routes/chat.py | aprovado | Correções pós-review T60-T69: arquivamento regra 08.5 (entradas #1-#38 → archive; 15 ativas restantes); ollama_embeddings com `Client(timeout=5.0)` + retries reduzidos para 4 (worst-case ~25s, era indeterminado); logger.info `chat.access` + warnings nos paths 503. Padrões Recorrentes ampliados com push sem autorização, arquivamento esquecido e checklist agêntico ausente. 129 testes, cobertura 83.23%. |
 | 55 | 2026-05-26 | TASK-T76 | minor | 7 arquivos — core/ollama_clients.py (novo), core/config.py, generation/llm.py, verification/entropy.py, retrieval/ollama_embeddings.py, tests/test_ollama_clients.py (novo), tests/test_verification.py, tests/test_integration.py | aprovado | Consolida 3 padrões de cliente Ollama em módulo único `core/ollama_clients.py` (singletons thread-safe). `settings.ollama_embed_timeout` substitui hardcode. Critério "nenhum `ollama.Client(...)` fora de core" verificado por grep. 7 novos testes (6 cobrindo singletons/timeouts/reset/independência + 1 caplog para chat.access). 136 testes, cobertura 85.87%. Wiki externa consultada (correção comportamental #1 do review T75). |
 | 56 | 2026-05-26 | TASK-T77 | patch | 1 arquivo — generation/llm.py | aprovado | Fix CI typecheck red em main desde T68: `# type: ignore[return-value]` substituído por `cast(dict[str, dict[str, str]], ...)` em `_ollama_chat`. Causa raiz: mypy CI (latest) detecta `unused-ignore` + `no-any-return` que mypy local (1.20.2 pin via uv) não dispara. Cast é runtime no-op + neutro a versão. Validação local com comando exato do CI passou. Padrão Recorrente "drift mypy CI vs local" adicionado; pinning de versão fica para T74. |
+| 57 | 2026-05-26 | TASK-T70 | minor | 8 arquivos — eval/_utils.py (novo), eval/__init__.py (novo), eval/generate_questions.py, eval/collect_references.py, eval/run_evaluation.py, eval/judge.py, eval/report.py, tests/test_eval.py (novo) | aprovado | Hardening pipeline `eval/`: paths absolutos via `Path(__file__).resolve()`, `validate_dataset_schema` em todos os entry points, erros como `{reference_answer: null, error: str}` em collect_references, checkpoint atômico (`.tmp + replace`) a cada 10 questões em run_evaluation com retomada por `question_id`, A/B determinístico via hash MD5 do `question_id` em judge (substituindo `random.random()`), filtro de qualidade `is_valid_question` (20-500 chars + `?`) em parse_questions_json, `report.py` exit 1 quando 0 julgamentos válidos. 45 novos testes em `test_eval.py` (helpers, checkpoint, erro estruturado, determinismo A/B, smoke judge→report). 173 testes (era 136), cobertura 83.07%, ruff + format + mypy strict ok. Compat retro mantida em judge para refs legadas `[ERRO]`. |
 
 ## Estado da Codebase
 
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
-- **Última atualização:** 2026-05-26 (TASK-T77 — fix mypy CI cast em _ollama_chat)
+- **Última atualização:** 2026-05-26 (TASK-T70 — hardening pipeline eval/)
 - **Último responsável:** Assistente (sessão local)
-- **Branch ativa:** fix/TASK-T77-mypy-strict-ci-cast
+- **Branch ativa:** feat/TASK-T70-eval-hardening
 - **Dependências alteradas recentemente:** nenhuma desde T60 — todas em main
-- **Testes passando:** sim — 136 passed, cobertura 85.89%; ruff + format + mypy local (CI command) ok
-- **Divergências externas pendentes:** PRs #74-#80 mergeadas em main; T77 local; CI typecheck em main red há 4 commits (T68→T76), corrigido por T77
-- **Última task concluída:** TASK-T77 — fix mypy CI typecheck via cast
-- **Backlog ativo:** 5 tasks pendentes (T70 ativa — hardening eval pipeline; T71–T74 enfileiradas)
-- **PRs abertos:** nenhum; PR T77 a abrir após push (com autorização)
+- **Testes passando:** sim — 173 passed (com integração: 181), cobertura 83.07%; ruff + format + mypy strict ok
+- **Divergências externas pendentes:** T77 já em main (#81); T70 local sem push
+- **Última task concluída:** TASK-T70 — hardening pipeline de avaliação
+- **Backlog ativo:** 4 tasks pendentes (T71 ativa — Docker hardening; T72–T74 enfileiradas)
+- **PRs abertos:** nenhum; PR T70 a abrir após autorização do desenvolvedor
 
 ## Pendências Conhecidas
 

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -84,37 +84,6 @@ A complexidade determina o nível de cerimônia na avaliação pós-implementaç
 > Tasks em andamento ou pendentes de implementação. O agente só pode trabalhar em tasks listadas aqui.
 > **Regra de ordenação:** A primeira task listada é a task ativa. O agente trabalha nela até conclusão, descarte ou bloqueio explícito pelo usuário. Para mudar a prioridade, o usuário reordena as tasks nesta seção.
 
-### TASK-T70
-- **Status:** pendente
-- **Modo:** desenvolvimento
-- **Complexidade:** minor
-- **Data de criação:** 2026-05-26
-
-#### Objetivo
-Robustecer pipeline de avaliação: paths via `__file__`, erros em campo separado, schema validation, checkpointing, exit codes (issue #57).
-
-#### Contexto
-`eval/` assume execução da raiz; erros de API armazenados como `[ERRO] ...` no campo `reference_answer`; sem validação entre etapas; sem checkpoint; exit code 0 em falha; A/B com seed não-determinístico.
-
-#### Escopo Técnico
-- **Arquivos/módulos envolvidos:** `eval/generate_questions.py`, `eval/collect_references.py`, `eval/run_evaluation.py`, `eval/judge.py`, `eval/report.py`, `tests/`
-- **Dependências necessárias:** nenhuma
-- **Impacto em funcionalidades existentes:** breaking apenas para datasets antigos com `[ERRO]` no campo answer (precisam reprocessar)
-
-#### Critérios de Aceite
-- [ ] Todos scripts usam `Path(__file__).parent` para resolver paths
-- [ ] `collect_references.py` armazena erros em `{"reference_answer": null, "error": str(e)}`
-- [ ] Função compartilhada `validate_dataset_schema(data, expected_keys)`
-- [ ] `run_evaluation.py` salva checkpoint a cada 10 questões
-- [ ] `report.py` exit 1 quando nenhum relatório gerado
-- [ ] `judge.py` A/B determinístico via hash de `question_id`
-- [ ] `generate_questions.py` valida qualidade (contém "?", 20-500 chars)
-- [ ] Smoke test do pipeline com fixture pequeno
-- [ ] `pytest`, `ruff`, `mypy` passam
-
-#### Referências
-- Issue: https://github.com/LukeSantossz/sb100_agents/issues/57
-
 ### TASK-T71
 - **Status:** pendente
 - **Modo:** desenvolvimento
@@ -246,6 +215,20 @@ A verificacao atual mostrou que `ruff check .` passa, mas `mypy retrieval/ gener
 ## Tasks Concluídas
 
 > Tasks finalizadas. Movidas para cá após conclusão e atualização do Registro de Projeto (`registry.md`). Nunca remova entradas — o histórico é cumulativo.
+
+### TASK-T70 — Hardening do pipeline de avaliação (issue #57) ✓
+- **Concluída em:** 2026-05-26
+- **Branch:** feat/TASK-T70-eval-hardening
+- **Commit:** pendente
+- **Avaliação:** aprovado
+- **Nota:** Robustece o pipeline `eval/`. (1) Novo módulo `eval/_utils.py` centraliza paths absolutos via `Path(__file__).resolve()`, `validate_dataset_schema`, `is_valid_question` (20–500 chars + `?`) e `deterministic_sb100_position_is_a` (hash MD5 do `question_id`, independente de `PYTHONHASHSEED`). (2) `collect_references.py` agora grava erros como `{"reference_model": ..., "reference_answer": null, "error": str(e)}`; sucesso traz `error: None`. (3) `run_evaluation.py` reescrito com checkpoint atômico a cada 10 questões (`evaluation_checkpoint.json` via `.tmp + replace`); retoma processamento filtrando `question_id`s já feitos; remove o checkpoint ao concluir. (4) `judge.py` substitui `random.random() < 0.5` por A/B determinístico via hash do `question_id`; aceita refs legadas (`[ERRO]`) e novas (`error` field); `import random` removido. (5) `report.py` retorna `bool` e `main()` exit 1 quando 0 julgamentos válidos. (6) Todos os 5 scripts agora usam defaults de paths absolutos baseados em `__file__` (independentes de CWD). (7) `validate_dataset_schema` aplicada em todos os entry points (`collect_references`, `run_evaluation`, `judge`, `report`). (8) `eval/__init__.py` (novo, vazio) torna `eval` package importável nos testes; `pyproject.toml` mantém `eval*` fora do build/coverage. (9) `tests/test_eval.py` (novo, 45 testes) cobre helpers, parse_questions_json (com filtro), parse_judge_response, normalize_verdict, checkpoint (roundtrip/missing/corrupted/atomic/filter), erro estruturado em collect_references, filtro de erros em judge (novo + legado), determinismo A/B, report (extract/distribution/stats/exit-1) e smoke judge→report end-to-end. 173 testes (era 136, +45 + 8 integration restaurados na execução = 218 quando todos), cobertura 83.07%, ruff + ruff format + mypy strict ok. Breaking: datasets antigos com `[ERRO] ...` em `reference_answer` continuam funcionando em `judge.py` (compat retro mantida), mas novos `collect_references` produzem o formato estruturado.
+
+#### Log de Andamento
+
+| Data | Sessão | Ação Realizada | Status ao Final |
+|------|--------|----------------|-----------------|
+| 2026-05-26 | 1 | Reconhecimento dos 5 scripts em `eval/`; plano declarado (helpers em `eval/_utils.py`, checkpoint atômico, hash MD5 para A/B determinístico); branch `feat/TASK-T70-eval-hardening` criada | em andamento |
+| 2026-05-26 | 1 | Implementação completa: `_utils`, atualização dos 5 scripts, novo `test_eval.py` (45 testes); pytest 173 ok, ruff + format ok, mypy strict ok | concluída |
 
 ### TASK-T77 — Fix mypy CI typecheck (cast em _ollama_chat) ✓
 - **Concluída em:** 2026-05-26

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Eval pipeline package marker."""

--- a/eval/_utils.py
+++ b/eval/_utils.py
@@ -1,0 +1,72 @@
+"""Utilitarios compartilhados do pipeline de avaliacao.
+
+Constantes de paths derivadas de `__file__` para permitir execucao
+de qualquer CWD; helpers de validacao de schema, qualidade de pergunta
+e decisao A/B deterministica.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+EVAL_DIR: Path = Path(__file__).resolve().parent
+PROJECT_ROOT: Path = EVAL_DIR.parent
+DATASET_DIR: Path = EVAL_DIR / "dataset"
+RESULTS_DIR: Path = EVAL_DIR / "results"
+
+DEFAULT_QUESTIONS_PATH: Path = DATASET_DIR / "questions.json"
+DEFAULT_REFERENCES_PATH: Path = DATASET_DIR / "reference_answers.json"
+DEFAULT_EVAL_RESULTS_PATH: Path = RESULTS_DIR / "evaluation_results.json"
+DEFAULT_JUDGED_RESULTS_PATH: Path = RESULTS_DIR / "judged_results.json"
+DEFAULT_REPORT_PATH: Path = RESULTS_DIR / "report.md"
+DEFAULT_HUMAN_SAMPLE_PATH: Path = RESULTS_DIR / "human_sample.csv"
+DEFAULT_CHECKPOINT_PATH: Path = RESULTS_DIR / "evaluation_checkpoint.json"
+
+QUESTION_MIN_LEN: int = 20
+QUESTION_MAX_LEN: int = 500
+
+
+def validate_dataset_schema(data: Any, expected_keys: list[str]) -> None:
+    """Valida que `data` e um dict contendo todas as chaves em `expected_keys`.
+
+    Args:
+        data: Objeto carregado de JSON (esperado dict).
+        expected_keys: Chaves obrigatorias no nivel raiz.
+
+    Raises:
+        ValueError: `data` nao e dict ou alguma chave esta ausente.
+    """
+    if not isinstance(data, dict):
+        raise ValueError(f"Dataset deve ser dict, recebido {type(data).__name__}")
+    missing = [key for key in expected_keys if key not in data]
+    if missing:
+        raise ValueError(f"Dataset sem chaves obrigatorias: {missing}")
+
+
+def is_valid_question(question: Any) -> bool:
+    """Filtro de qualidade: string contendo '?' com 20-500 caracteres."""
+    if not isinstance(question, str):
+        return False
+    stripped = question.strip()
+    if "?" not in stripped:
+        return False
+    return QUESTION_MIN_LEN <= len(stripped) <= QUESTION_MAX_LEN
+
+
+def deterministic_sb100_position_is_a(question_id: str) -> bool:
+    """Decide a posicao do SB100 (A ou B) de forma deterministica.
+
+    Usa hash MD5 do `question_id` para evitar dependencia de
+    `random.seed()` ou de `PYTHONHASHSEED`. Mesmo `question_id` sempre
+    retorna o mesmo lado, permitindo reproducibilidade entre execucoes.
+
+    Args:
+        question_id: Identificador unico da pergunta.
+
+    Returns:
+        True se SB100 deve ocupar a posicao A; False para posicao B.
+    """
+    digest = hashlib.md5(question_id.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 2 == 0

--- a/eval/collect_references.py
+++ b/eval/collect_references.py
@@ -15,15 +15,24 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # Carrega variaveis de ambiente do .env
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import argparse
 import json
 import os
+import sys
 from datetime import UTC, datetime
-from pathlib import Path
 
 from tqdm import tqdm
+
+# Permite `from eval._utils import ...` em execucao standalone
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval._utils import (
+    DEFAULT_QUESTIONS_PATH,
+    DEFAULT_REFERENCES_PATH,
+    validate_dataset_schema,
+)
 
 # Providers disponiveis: groq, ollama, openrouter
 DEFAULT_PROVIDER = "groq"
@@ -111,8 +120,8 @@ def get_reference_openrouter(
 
 
 def collect_references(
-    questions_path: str = "eval/dataset/questions.json",
-    output_path: str = "eval/dataset/reference_answers.json",
+    questions_path: str = str(DEFAULT_QUESTIONS_PATH),
+    output_path: str = str(DEFAULT_REFERENCES_PATH),
     provider: str = DEFAULT_PROVIDER,
     models: list[str] | None = None,
 ) -> dict:
@@ -142,6 +151,8 @@ def collect_references(
     with open(questions_path, encoding="utf-8") as f:
         dataset = json.load(f)
 
+    validate_dataset_schema(dataset, ["metadata", "questions"])
+
     questions = dataset["questions"]
     print(f"Carregadas {len(questions)} perguntas de {questions_path}")
     print(f"Modelos de referencia: {models}")
@@ -165,14 +176,16 @@ def collect_references(
                     {
                         "reference_model": model,
                         "reference_answer": answer,
+                        "error": None,
                     }
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - propaga via campo `error`
                 print(f"\nErro com modelo {model}: {e}")
                 question_obj["reference_answers"].append(
                     {
                         "reference_model": model,
-                        "reference_answer": f"[ERRO] {str(e)}",
+                        "reference_answer": None,
+                        "error": str(e),
                     }
                 )
 
@@ -203,13 +216,13 @@ def main():
     )
     parser.add_argument(
         "--input",
-        default="eval/dataset/questions.json",
-        help="Caminho do dataset de perguntas (padrao: eval/dataset/questions.json)",
+        default=str(DEFAULT_QUESTIONS_PATH),
+        help=f"Caminho do dataset de perguntas (padrao: {DEFAULT_QUESTIONS_PATH})",
     )
     parser.add_argument(
         "--output",
-        default="eval/dataset/reference_answers.json",
-        help="Caminho do arquivo de saida (padrao: eval/dataset/reference_answers.json)",
+        default=str(DEFAULT_REFERENCES_PATH),
+        help=f"Caminho do arquivo de saida (padrao: {DEFAULT_REFERENCES_PATH})",
     )
     parser.add_argument(
         "--provider",

--- a/eval/generate_questions.py
+++ b/eval/generate_questions.py
@@ -14,17 +14,22 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # Carrega variaveis de ambiente do .env
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import argparse
 import json
 import os
 import re
+import sys
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
 
 import fitz  # PyMuPDF
+
+# Permite `from eval._utils import ...` em execucao standalone
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval._utils import DEFAULT_QUESTIONS_PATH, is_valid_question
 
 # Providers disponiveis: groq, ollama, openrouter
 DEFAULT_PROVIDER = "groq"
@@ -175,30 +180,35 @@ def generate_questions_openrouter(
 
 
 def parse_questions_json(content: str) -> list[str]:
-    """Extrai lista de perguntas do JSON retornado pelo LLM."""
+    """Extrai lista de perguntas do JSON retornado pelo LLM.
+
+    Aplica filtro de qualidade `is_valid_question` (contem '?', 20-500 chars)
+    para descartar lixo do LLM (linhas vazias, fragmentos, prefacios).
+    """
+    candidates: list[str] = []
+
     # Tenta extrair JSON array do conteudo
     json_match = re.search(r"\[.*\]", content, re.DOTALL)
     if json_match:
         try:
-            questions = json.loads(json_match.group())
-            if isinstance(questions, list):
-                return [q for q in questions if isinstance(q, str) and q.strip()]
+            parsed = json.loads(json_match.group())
+            if isinstance(parsed, list):
+                candidates = [q for q in parsed if isinstance(q, str) and q.strip()]
         except json.JSONDecodeError:
             pass
 
-    # Fallback: extrai linhas que parecem perguntas
-    lines = content.split("\n")
-    questions = []
-    for line in lines:
-        line = line.strip()
-        # Remove prefixos numerados
-        line = re.sub(r"^[\d]+[.\-\)]\s*", "", line)
-        line = re.sub(r'^["\']\s*', "", line)
-        line = re.sub(r'\s*["\']$', "", line)
-        if line and "?" in line:
-            questions.append(line)
+    if not candidates:
+        # Fallback: extrai linhas que parecem perguntas
+        for raw_line in content.split("\n"):
+            line = raw_line.strip()
+            # Remove prefixos numerados
+            line = re.sub(r"^[\d]+[.\-\)]\s*", "", line)
+            line = re.sub(r'^["\']\s*', "", line)
+            line = re.sub(r'\s*["\']$', "", line)
+            if line and "?" in line:
+                candidates.append(line)
 
-    return questions
+    return [q.strip() for q in candidates if is_valid_question(q)]
 
 
 def collect_files(path: str) -> list[str]:
@@ -331,8 +341,8 @@ def main():
     )
     parser.add_argument(
         "--output",
-        default="eval/dataset/questions.json",
-        help="Caminho do arquivo de saida (padrao: eval/dataset/questions.json)",
+        default=str(DEFAULT_QUESTIONS_PATH),
+        help=f"Caminho do arquivo de saida (padrao: {DEFAULT_QUESTIONS_PATH})",
     )
 
     args = parser.parse_args()

--- a/eval/judge.py
+++ b/eval/judge.py
@@ -14,17 +14,26 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # Carrega variaveis de ambiente do .env
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import argparse
 import json
 import os
-import random
 import re
+import sys
 from datetime import UTC, datetime
-from pathlib import Path
 
 from tqdm import tqdm
+
+# Permite `from eval._utils import ...` em execucao standalone
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval._utils import (
+    DEFAULT_EVAL_RESULTS_PATH,
+    DEFAULT_JUDGED_RESULTS_PATH,
+    deterministic_sb100_position_is_a,
+    validate_dataset_schema,
+)
 
 # Provider padrao
 DEFAULT_PROVIDER = "groq"
@@ -198,8 +207,8 @@ def normalize_verdict(verdict: str, sb100_was_a: bool) -> str:
 
 
 def run_judge(
-    input_path: str = "eval/results/evaluation_results.json",
-    output_path: str = "eval/results/judged_results.json",
+    input_path: str = str(DEFAULT_EVAL_RESULTS_PATH),
+    output_path: str = str(DEFAULT_JUDGED_RESULTS_PATH),
     provider: str = DEFAULT_PROVIDER,
     model: str | None = None,
 ) -> dict:
@@ -229,17 +238,19 @@ def run_judge(
     with open(input_path, encoding="utf-8") as f:
         dataset = json.load(f)
 
+    validate_dataset_schema(dataset, ["metadata", "results"])
+
     results = dataset["results"]
     print(f"Carregados {len(results)} resultados de {input_path}")
     print(f"Modelo juiz: {model} ({provider})")
 
     # Processa cada resultado
     judged_results = []
-    random.seed(42)  # Reproducibilidade
 
     for result in tqdm(results, desc="Julgando respostas"):
         sb100_answer = result.get("sb100_answer", "")
         reference_answers = result.get("reference_answers", [])
+        question_id = result.get("question_id", "")
 
         if not result.get("sb100_success", True):
             # Pula resultados com erro
@@ -255,13 +266,21 @@ def run_judge(
 
         for ref in reference_answers:
             ref_model = ref.get("reference_model", "unknown")
-            ref_answer = ref.get("reference_answer", "")
+            ref_answer = ref.get("reference_answer")
+            ref_error = ref.get("error")
 
-            if not ref_answer or ref_answer.startswith("[ERRO]"):
+            # Ignora referencias com erro estruturado (novo formato),
+            # ausentes ou no formato legado "[ERRO] ..."
+            if (
+                ref_error is not None
+                or not ref_answer
+                or (isinstance(ref_answer, str) and ref_answer.startswith("[ERRO]"))
+            ):
                 continue
 
-            # Alterna ordem para evitar vies de posicao (50% cada)
-            sb100_is_a = random.random() < 0.5
+            # A/B deterministico via hash(question_id) — evita vies sem
+            # depender de random.seed/PYTHONHASHSEED
+            sb100_is_a = deterministic_sb100_position_is_a(question_id)
 
             if sb100_is_a:
                 answer_a, answer_b = sb100_answer, ref_answer
@@ -356,13 +375,13 @@ def main():
     parser = argparse.ArgumentParser(description="Executa julgamento automatico das respostas")
     parser.add_argument(
         "--input",
-        default="eval/results/evaluation_results.json",
-        help="Caminho dos resultados da avaliacao (padrao: eval/results/evaluation_results.json)",
+        default=str(DEFAULT_EVAL_RESULTS_PATH),
+        help=f"Caminho dos resultados da avaliacao (padrao: {DEFAULT_EVAL_RESULTS_PATH})",
     )
     parser.add_argument(
         "--output",
-        default="eval/results/judged_results.json",
-        help="Caminho do arquivo de saida (padrao: eval/results/judged_results.json)",
+        default=str(DEFAULT_JUDGED_RESULTS_PATH),
+        help=f"Caminho do arquivo de saida (padrao: {DEFAULT_JUDGED_RESULTS_PATH})",
     )
     parser.add_argument(
         "--provider",

--- a/eval/report.py
+++ b/eval/report.py
@@ -16,10 +16,21 @@ import argparse
 import csv
 import json
 import random
+import sys
 from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from statistics import mean, median
+
+# Permite `from eval._utils import ...` em execucao standalone
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval._utils import (
+    DEFAULT_HUMAN_SAMPLE_PATH,
+    DEFAULT_JUDGED_RESULTS_PATH,
+    DEFAULT_REPORT_PATH,
+    validate_dataset_schema,
+)
 
 
 def load_judged_results(input_path: str) -> dict:
@@ -253,11 +264,11 @@ def export_human_sample(
 
 
 def generate_report(
-    input_path: str = "eval/results/judged_results.json",
-    report_path: str = "eval/results/report.md",
-    sample_path: str = "eval/results/human_sample.csv",
+    input_path: str = str(DEFAULT_JUDGED_RESULTS_PATH),
+    report_path: str = str(DEFAULT_REPORT_PATH),
+    sample_path: str = str(DEFAULT_HUMAN_SAMPLE_PATH),
     sample_size: int = 30,
-) -> None:
+) -> bool:
     """
     Gera relatorio completo da avaliacao.
 
@@ -266,9 +277,13 @@ def generate_report(
         report_path: Caminho do relatorio MD
         sample_path: Caminho do CSV de amostra humana
         sample_size: Tamanho da amostra humana
+
+    Returns:
+        True se o relatorio foi gerado; False se nao havia julgamentos validos.
     """
     # Carrega dados
     dataset = load_judged_results(input_path)
+    validate_dataset_schema(dataset, ["results"])
     results = dataset.get("results", [])
     metadata = dataset.get("metadata", {})
 
@@ -280,7 +295,7 @@ def generate_report(
 
     if not judgments:
         print("Nenhum julgamento encontrado. Verifique o arquivo de entrada.")
-        return
+        return False
 
     # Gera estatisticas
     score_distribution = generate_score_distribution(judgments)
@@ -304,23 +319,25 @@ def generate_report(
     sample = export_human_sample(judgments, sample_path, sample_size)
     print(f"Amostra humana ({len(sample)} itens) salva em: {sample_path}")
 
+    return True
+
 
 def main():
     parser = argparse.ArgumentParser(description="Gera relatorio sumario da avaliacao")
     parser.add_argument(
         "--input",
-        default="eval/results/judged_results.json",
-        help="Caminho do dataset julgado (padrao: eval/results/judged_results.json)",
+        default=str(DEFAULT_JUDGED_RESULTS_PATH),
+        help=f"Caminho do dataset julgado (padrao: {DEFAULT_JUDGED_RESULTS_PATH})",
     )
     parser.add_argument(
         "--report",
-        default="eval/results/report.md",
-        help="Caminho do relatorio (padrao: eval/results/report.md)",
+        default=str(DEFAULT_REPORT_PATH),
+        help=f"Caminho do relatorio (padrao: {DEFAULT_REPORT_PATH})",
     )
     parser.add_argument(
         "--sample",
-        default="eval/results/human_sample.csv",
-        help="Caminho do CSV de amostra humana (padrao: eval/results/human_sample.csv)",
+        default=str(DEFAULT_HUMAN_SAMPLE_PATH),
+        help=f"Caminho do CSV de amostra humana (padrao: {DEFAULT_HUMAN_SAMPLE_PATH})",
     )
     parser.add_argument(
         "--sample-size",
@@ -337,15 +354,15 @@ def main():
         print("Execute primeiro: python eval/judge.py")
         return 1
 
-    # Gera relatorio
-    generate_report(
+    # Gera relatorio; exit 1 quando nenhum julgamento valido
+    ok = generate_report(
         input_path=args.input,
         report_path=args.report,
         sample_path=args.sample,
         sample_size=args.sample_size,
     )
 
-    return 0
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/eval/run_evaluation.py
+++ b/eval/run_evaluation.py
@@ -5,6 +5,10 @@ Itera sobre o dataset de perguntas, executa POST /chat para cada uma
 com session_id unico (impede contaminacao de historico), e salva as
 respostas do SB100 no dataset de resultados.
 
+Suporta checkpointing: a cada `CHECKPOINT_EVERY` resultados, persiste
+estado parcial em `evaluation_checkpoint.json`. Se interrompido, a
+proxima execucao retoma apenas das perguntas pendentes.
+
 Uso:
     python eval/run_evaluation.py
     python eval/run_evaluation.py --api-url http://localhost:8000 --concurrent 5
@@ -13,6 +17,7 @@ Uso:
 import argparse
 import asyncio
 import json
+import sys
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -20,11 +25,22 @@ from pathlib import Path
 import httpx
 from tqdm import tqdm
 
+# Permite `from eval._utils import ...` em execucao standalone
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval._utils import (
+    DEFAULT_CHECKPOINT_PATH,
+    DEFAULT_EVAL_RESULTS_PATH,
+    DEFAULT_REFERENCES_PATH,
+    validate_dataset_schema,
+)
+
 # Configuracoes padrao
 DEFAULT_API_URL = "http://localhost:8000"
 DEFAULT_PROFILE = {"name": "eval", "expertise": "intermediate"}
 DEFAULT_CONCURRENT = 1  # Requests simultaneos (1 = sequencial)
 DEFAULT_TIMEOUT = 300.0  # Timeout por request em segundos (5 min para Ollama local)
+CHECKPOINT_EVERY = 10  # Persiste estado parcial a cada N resultados
 
 
 async def call_chat_api(
@@ -81,26 +97,79 @@ async def call_chat_api(
         }
 
 
+def load_checkpoint(checkpoint_path: Path) -> list[dict]:
+    """Carrega resultados parciais de um checkpoint, se existir.
+
+    Retorna lista vazia se o checkpoint nao existir ou estiver corrompido.
+    """
+    if not checkpoint_path.exists():
+        return []
+    try:
+        with open(checkpoint_path, encoding="utf-8") as f:
+            data = json.load(f)
+        results = data.get("results", [])
+        if isinstance(results, list):
+            return [r for r in results if isinstance(r, dict) and "question_id" in r]
+        return []
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Aviso: checkpoint corrompido ({e}); ignorando")
+        return []
+
+
+def save_checkpoint(checkpoint_path: Path, results: list[dict]) -> None:
+    """Persiste resultados parciais em arquivo atomico.
+
+    Escreve em `.tmp` e renomeia, evitando corrupcao se for interrompido
+    durante a escrita.
+    """
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = checkpoint_path.with_suffix(checkpoint_path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump({"results": results}, f, ensure_ascii=False, indent=2)
+    tmp.replace(checkpoint_path)
+
+
 async def run_evaluation_async(
     questions: list[dict],
     api_url: str = DEFAULT_API_URL,
     concurrent: int = DEFAULT_CONCURRENT,
+    checkpoint_path: Path = DEFAULT_CHECKPOINT_PATH,
+    checkpoint_every: int = CHECKPOINT_EVERY,
 ) -> list[dict]:
     """
-    Executa avaliacao de todas as perguntas de forma assincrona.
+    Executa avaliacao de todas as perguntas de forma assincrona, com
+    persistencia incremental de progresso via checkpoint.
 
     Args:
         questions: Lista de objetos question do dataset
         api_url: URL base da API
         concurrent: Numero de requests simultaneos
+        checkpoint_path: Arquivo para gravar progresso parcial
+        checkpoint_every: Intervalo (em resultados completos) para flush
 
     Returns:
-        Lista de resultados
+        Lista de resultados (existentes do checkpoint + novos)
     """
-    results = []
+    existing = load_checkpoint(checkpoint_path)
+    completed_ids = {r["question_id"] for r in existing}
+    pending = [q for q in questions if q["question_id"] not in completed_ids]
+
+    if existing:
+        print(
+            f"Checkpoint encontrado em {checkpoint_path}: "
+            f"{len(existing)} resultados ja processados; "
+            f"retomando {len(pending)} pendentes"
+        )
+
+    results: list[dict] = list(existing)
+
+    if not pending:
+        print("Nenhuma pergunta pendente.")
+        return results
+
     semaphore = asyncio.Semaphore(concurrent)
 
-    async def process_question(question_obj: dict) -> dict:
+    async def process_question(question_obj: dict, client: httpx.AsyncClient) -> dict:
         async with semaphore:
             result = await call_chat_api(
                 client,
@@ -125,10 +194,11 @@ async def run_evaluation_async(
             print(f"API disponivel: {api_url}")
         except Exception as e:
             print(f"Erro: API nao disponivel em {api_url}: {e}")
-            return []
+            return results
 
         # Processa perguntas com barra de progresso
-        tasks = [process_question(q) for q in questions]
+        tasks = [process_question(q, client) for q in pending]
+        new_since_checkpoint = 0
 
         for task in tqdm(
             asyncio.as_completed(tasks),
@@ -137,6 +207,11 @@ async def run_evaluation_async(
         ):
             result = await task
             results.append(result)
+            new_since_checkpoint += 1
+
+            if new_since_checkpoint >= checkpoint_every:
+                save_checkpoint(checkpoint_path, results)
+                new_since_checkpoint = 0
 
     # Reordena por question_id para manter ordem original
     results.sort(key=lambda x: x["question_id"])
@@ -145,10 +220,11 @@ async def run_evaluation_async(
 
 
 def run_evaluation(
-    input_path: str = "eval/dataset/reference_answers.json",
-    output_path: str = "eval/results/evaluation_results.json",
+    input_path: str = str(DEFAULT_REFERENCES_PATH),
+    output_path: str = str(DEFAULT_EVAL_RESULTS_PATH),
     api_url: str = DEFAULT_API_URL,
     concurrent: int = DEFAULT_CONCURRENT,
+    checkpoint_path: str | None = None,
 ) -> dict:
     """
     Executa avaliacao completa do SB100.
@@ -158,21 +234,27 @@ def run_evaluation(
         output_path: Caminho do arquivo de saida
         api_url: URL base da API
         concurrent: Numero de requests simultaneos
+        checkpoint_path: Caminho do checkpoint (padrao: DEFAULT_CHECKPOINT_PATH)
 
     Returns:
         Dataset de resultados
     """
+    checkpoint = Path(checkpoint_path) if checkpoint_path else DEFAULT_CHECKPOINT_PATH
+
     # Carrega dataset
     with open(input_path, encoding="utf-8") as f:
         dataset = json.load(f)
+
+    validate_dataset_schema(dataset, ["metadata", "questions"])
 
     questions = dataset["questions"]
     print(f"Carregadas {len(questions)} perguntas de {input_path}")
     print(f"API URL: {api_url}")
     print(f"Requests simultaneos: {concurrent}")
+    print(f"Checkpoint: {checkpoint} (a cada {CHECKPOINT_EVERY} resultados)")
 
     # Executa avaliacao
-    results = asyncio.run(run_evaluation_async(questions, api_url, concurrent))
+    results = asyncio.run(run_evaluation_async(questions, api_url, concurrent, checkpoint))
 
     if not results:
         print("Nenhum resultado obtido. Verifique se a API esta disponivel.")
@@ -203,6 +285,10 @@ def run_evaluation(
     with open(output, "w", encoding="utf-8") as f:
         json.dump(results_dataset, f, ensure_ascii=False, indent=2)
 
+    # Limpa checkpoint ao concluir com sucesso
+    if checkpoint.exists():
+        checkpoint.unlink()
+
     print(f"\nResultados salvos em: {output}")
     print(f"Requests bem-sucedidos: {successful}/{len(results)}")
     if failed > 0:
@@ -211,19 +297,19 @@ def run_evaluation(
     return results_dataset
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="Executa avaliacao do SB100 contra o dataset de perguntas"
     )
     parser.add_argument(
         "--input",
-        default="eval/dataset/reference_answers.json",
-        help="Caminho do dataset com referencias (padrao: eval/dataset/reference_answers.json)",
+        default=str(DEFAULT_REFERENCES_PATH),
+        help=f"Caminho do dataset com referencias (padrao: {DEFAULT_REFERENCES_PATH})",
     )
     parser.add_argument(
         "--output",
-        default="eval/results/evaluation_results.json",
-        help="Caminho do arquivo de saida (padrao: eval/results/evaluation_results.json)",
+        default=str(DEFAULT_EVAL_RESULTS_PATH),
+        help=f"Caminho do arquivo de saida (padrao: {DEFAULT_EVAL_RESULTS_PATH})",
     )
     parser.add_argument(
         "--api-url",
@@ -235,6 +321,11 @@ def main():
         type=int,
         default=DEFAULT_CONCURRENT,
         help=f"Requests simultaneos (padrao: {DEFAULT_CONCURRENT})",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default=str(DEFAULT_CHECKPOINT_PATH),
+        help=f"Arquivo de checkpoint (padrao: {DEFAULT_CHECKPOINT_PATH})",
     )
 
     args = parser.parse_args()
@@ -253,6 +344,7 @@ def main():
         output_path=args.output,
         api_url=args.api_url,
         concurrent=args.concurrent,
+        checkpoint_path=args.checkpoint,
     )
 
     return 0 if result else 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,8 @@ ignore_errors = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+# Adds project root to sys.path so non-package directories (e.g. eval/) are importable in tests
+pythonpath = ["."]
 addopts = [
     "-v",
     "--cov=api",

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,636 @@
+"""Smoke tests para o pipeline de avaliacao (eval/).
+
+Cobre: helpers em `eval/_utils`, filtro de qualidade em
+`generate_questions`, formato de erro estruturado em `collect_references`,
+checkpoint atomico em `run_evaluation`, A/B deterministico e filtro de
+erros em `judge`, e exit-code/markdown em `report`.
+
+Sem chamadas reais a APIs (Groq/Ollama/OpenRouter); todos os providers
+sao substituidos via `monkeypatch`.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+
+import pytest
+
+from eval._utils import (
+    deterministic_sb100_position_is_a,
+    is_valid_question,
+    validate_dataset_schema,
+)
+from eval.generate_questions import parse_questions_json
+from eval.judge import normalize_verdict, parse_judge_response
+from eval.report import (
+    extract_all_judgments,
+    generate_report,
+    generate_score_distribution,
+    generate_verdict_stats,
+)
+from eval.run_evaluation import load_checkpoint, save_checkpoint
+
+# ============================================================================
+# _utils
+# ============================================================================
+
+
+class TestValidateDatasetSchema:
+    def test_valid(self) -> None:
+        validate_dataset_schema({"a": 1, "b": 2}, ["a", "b"])
+
+    def test_missing_key(self) -> None:
+        with pytest.raises(ValueError, match="obrigatorias"):
+            validate_dataset_schema({"a": 1}, ["a", "b"])
+
+    def test_not_dict(self) -> None:
+        with pytest.raises(ValueError, match="deve ser dict"):
+            validate_dataset_schema([1, 2, 3], ["a"])
+
+    def test_empty_expected_keys(self) -> None:
+        validate_dataset_schema({"qualquer": "coisa"}, [])
+
+
+class TestIsValidQuestion:
+    @pytest.mark.parametrize(
+        "question",
+        [
+            "Qual e a melhor pratica de irrigacao no cerrado?",
+            "Como funciona a rotacao de culturas em pequenas propriedades?",
+        ],
+    )
+    def test_valid(self, question: str) -> None:
+        assert is_valid_question(question) is True
+
+    def test_too_short(self) -> None:
+        assert is_valid_question("Curto?") is False
+
+    def test_too_long(self) -> None:
+        assert is_valid_question("A" * 600 + "?") is False
+
+    def test_no_question_mark(self) -> None:
+        assert is_valid_question("Um enunciado declarativo de tamanho razoavel.") is False
+
+    def test_non_string(self) -> None:
+        assert is_valid_question(None) is False
+        assert is_valid_question(123) is False
+
+    def test_empty(self) -> None:
+        assert is_valid_question("") is False
+
+    def test_only_whitespace(self) -> None:
+        assert is_valid_question("   \n\t   ") is False
+
+
+class TestDeterministicABPosition:
+    def test_consistent_across_calls(self) -> None:
+        qid = "abc-123-def-456"
+        assert deterministic_sb100_position_is_a(qid) == deterministic_sb100_position_is_a(qid)
+
+    def test_different_ids_balanced_distribution(self) -> None:
+        # 1000 ids → distribuicao ~50/50 (tolerancia ampla para MD5)
+        ids = [f"q-{i:04d}" for i in range(1000)]
+        a_count = sum(1 for qid in ids if deterministic_sb100_position_is_a(qid))
+        assert 400 < a_count < 600
+
+    def test_independent_of_random_seed(self) -> None:
+        qid = "fixed-question-id"
+        first = deterministic_sb100_position_is_a(qid)
+        random.seed(42)
+        second = deterministic_sb100_position_is_a(qid)
+        random.seed(0)
+        third = deterministic_sb100_position_is_a(qid)
+        assert first == second == third
+
+
+# ============================================================================
+# generate_questions
+# ============================================================================
+
+
+class TestParseQuestionsJson:
+    def test_valid_json_array(self) -> None:
+        content = (
+            "[\n"
+            '  "Qual e a melhor pratica de irrigacao no cerrado?",\n'
+            '  "Como funciona a rotacao de culturas em propriedades?"\n'
+            "]"
+        )
+        result = parse_questions_json(content)
+        assert len(result) == 2
+
+    def test_filters_short_questions(self) -> None:
+        content = '["Q?", "Pergunta valida com tamanho suficiente?"]'
+        result = parse_questions_json(content)
+        # "Q?" tem 2 chars → filtrada; segunda tem 38 chars → ok
+        assert len(result) == 1
+        assert result[0] == "Pergunta valida com tamanho suficiente?"
+
+    def test_filters_no_question_mark(self) -> None:
+        content = (
+            '["Frase declarativa sem ponto de interrogacao", '
+            '"Frase interrogativa com ponto adequado aqui?"]'
+        )
+        result = parse_questions_json(content)
+        assert len(result) == 1
+        assert "?" in result[0]
+
+    def test_fallback_lines_parsing(self) -> None:
+        content = (
+            "1. Qual e a melhor estacao de plantio para milho safrinha?\n"
+            "2. Como fertilizar o solo de forma sustentavel no cerrado?"
+        )
+        result = parse_questions_json(content)
+        assert len(result) == 2
+
+    def test_empty_returns_empty(self) -> None:
+        assert parse_questions_json("") == []
+
+    def test_non_string_items_filtered(self) -> None:
+        content = '["Pergunta valida com tamanho suficiente aqui?", 42, null]'
+        result = parse_questions_json(content)
+        assert len(result) == 1
+
+
+# ============================================================================
+# judge
+# ============================================================================
+
+
+class TestParseJudgeResponse:
+    def test_valid_json(self) -> None:
+        content = (
+            '{"score_a": 8, "score_b": 5, "justification": "A e melhor", "verdict": "A_better"}'
+        )
+        result = parse_judge_response(content)
+        assert result["score_a"] == 8.0
+        assert result["score_b"] == 5.0
+        assert result["verdict"] == "A_better"
+
+    def test_invalid_json_fallback_neutral(self) -> None:
+        result = parse_judge_response("texto sem json valido aqui")
+        assert result["score_a"] == 5.0
+        assert result["score_b"] == 5.0
+        assert "[PARSE ERROR]" in result["justification"]
+
+
+class TestNormalizeVerdict:
+    def test_a_better_when_sb100_was_a(self) -> None:
+        assert normalize_verdict("A_better", True) == "better"
+
+    def test_a_better_when_sb100_was_b(self) -> None:
+        assert normalize_verdict("A_better", False) == "worse"
+
+    def test_b_better_when_sb100_was_a(self) -> None:
+        assert normalize_verdict("B_better", True) == "worse"
+
+    def test_b_better_when_sb100_was_b(self) -> None:
+        assert normalize_verdict("B_better", False) == "better"
+
+    def test_equivalent(self) -> None:
+        assert normalize_verdict("equivalent", True) == "equivalent"
+        assert normalize_verdict("equivalent", False) == "equivalent"
+
+
+# ============================================================================
+# run_evaluation: checkpoint
+# ============================================================================
+
+
+class TestCheckpoint:
+    def test_roundtrip(self, tmp_path) -> None:
+        path = tmp_path / "checkpoint.json"
+        results = [
+            {"question_id": "q1", "sb100_answer": "r1", "sb100_success": True},
+            {"question_id": "q2", "sb100_answer": "r2", "sb100_success": True},
+        ]
+        save_checkpoint(path, results)
+        loaded = load_checkpoint(path)
+        assert loaded == results
+
+    def test_missing_returns_empty(self, tmp_path) -> None:
+        assert load_checkpoint(tmp_path / "nao_existe.json") == []
+
+    def test_corrupted_returns_empty(self, tmp_path) -> None:
+        path = tmp_path / "corrupto.json"
+        path.write_text("not valid json {", encoding="utf-8")
+        assert load_checkpoint(path) == []
+
+    def test_atomic_replace_keeps_consistent(self, tmp_path) -> None:
+        path = tmp_path / "checkpoint.json"
+        save_checkpoint(path, [{"question_id": "q1"}])
+        save_checkpoint(path, [{"question_id": "q1"}, {"question_id": "q2"}])
+        assert len(load_checkpoint(path)) == 2
+
+    def test_load_filters_invalid_entries(self, tmp_path) -> None:
+        path = tmp_path / "ck.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {"question_id": "q1"},
+                        "string solta sem question_id",
+                        {"sem_question_id": True},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        loaded = load_checkpoint(path)
+        assert loaded == [{"question_id": "q1"}]
+
+
+# ============================================================================
+# collect_references: erro estruturado
+# ============================================================================
+
+
+class TestCollectReferencesErrorStructure:
+    def test_error_stored_as_structured_field(self, tmp_path, monkeypatch) -> None:
+        from eval import collect_references as cr
+
+        questions_data = {
+            "metadata": {"source_documents": ["fake.pdf"]},
+            "questions": [
+                {
+                    "question_id": "q1",
+                    "question": "Pergunta valida com tamanho suficiente para teste?",
+                    "reference_answers": [],
+                }
+            ],
+        }
+        input_path = tmp_path / "questions.json"
+        output_path = tmp_path / "references.json"
+        input_path.write_text(json.dumps(questions_data), encoding="utf-8")
+
+        def fake_get_ref(question: str, model: str) -> str:
+            raise RuntimeError("API down")
+
+        monkeypatch.setattr(cr, "get_reference_groq", fake_get_ref)
+
+        cr.collect_references(
+            questions_path=str(input_path),
+            output_path=str(output_path),
+            provider="groq",
+            models=["model-x"],
+        )
+
+        data = json.loads(output_path.read_text(encoding="utf-8"))
+        ref = data["questions"][0]["reference_answers"][0]
+        assert ref["reference_model"] == "model-x"
+        assert ref["reference_answer"] is None
+        assert ref["error"] == "API down"
+
+    def test_success_stores_answer_with_null_error(self, tmp_path, monkeypatch) -> None:
+        from eval import collect_references as cr
+
+        questions_data = {
+            "metadata": {},
+            "questions": [
+                {
+                    "question_id": "q1",
+                    "question": "Pergunta de teste valida e suficientemente longa?",
+                    "reference_answers": [],
+                }
+            ],
+        }
+        input_path = tmp_path / "questions.json"
+        output_path = tmp_path / "references.json"
+        input_path.write_text(json.dumps(questions_data), encoding="utf-8")
+
+        monkeypatch.setattr(cr, "get_reference_groq", lambda q, m: "Resposta OK")
+
+        cr.collect_references(
+            questions_path=str(input_path),
+            output_path=str(output_path),
+            provider="groq",
+            models=["model-ok"],
+        )
+
+        data = json.loads(output_path.read_text(encoding="utf-8"))
+        ref = data["questions"][0]["reference_answers"][0]
+        assert ref["reference_answer"] == "Resposta OK"
+        assert ref["error"] is None
+
+
+# ============================================================================
+# judge: filtro de erro + smoke
+# ============================================================================
+
+
+class TestJudgeFiltersErrors:
+    def _eval_results(self, refs: list[dict]) -> dict:
+        return {
+            "metadata": {},
+            "results": [
+                {
+                    "question_id": "q1",
+                    "question": "Pergunta de teste valida?",
+                    "sb100_answer": "resposta SB100",
+                    "sb100_hallucination_score": 0.1,
+                    "sb100_session_id": "s",
+                    "sb100_success": True,
+                    "reference_answers": refs,
+                }
+            ],
+        }
+
+    def test_skips_new_format_error(self, tmp_path, monkeypatch) -> None:
+        from eval import judge as jd
+
+        data = self._eval_results(
+            [
+                {
+                    "reference_model": "model-broken",
+                    "reference_answer": None,
+                    "error": "API down",
+                },
+                {
+                    "reference_model": "model-ok",
+                    "reference_answer": "Resposta OK",
+                    "error": None,
+                },
+            ]
+        )
+        input_path = tmp_path / "eval.json"
+        output_path = tmp_path / "judged.json"
+        input_path.write_text(json.dumps(data), encoding="utf-8")
+
+        monkeypatch.setattr(
+            jd,
+            "judge_groq",
+            lambda q, a, b, m: {
+                "score_a": 7.0,
+                "score_b": 5.0,
+                "justification": "ok",
+                "verdict": "A_better",
+            },
+        )
+
+        jd.run_judge(
+            input_path=str(input_path),
+            output_path=str(output_path),
+            provider="groq",
+            model="judge-model",
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        judgments = result["results"][0]["judgments"]
+        assert len(judgments) == 1
+        assert judgments[0]["reference_model"] == "model-ok"
+
+    def test_skips_legacy_format_error(self, tmp_path, monkeypatch) -> None:
+        from eval import judge as jd
+
+        data = self._eval_results(
+            [
+                {
+                    "reference_model": "model-legacy",
+                    "reference_answer": "[ERRO] formato antigo",
+                }
+            ]
+        )
+        input_path = tmp_path / "eval.json"
+        output_path = tmp_path / "judged.json"
+        input_path.write_text(json.dumps(data), encoding="utf-8")
+
+        def fake_judge(*_args: object, **_kwargs: object) -> dict:
+            pytest.fail("Judge nao deveria ser chamado para refs com erro")
+
+        monkeypatch.setattr(jd, "judge_groq", fake_judge)
+
+        jd.run_judge(
+            input_path=str(input_path),
+            output_path=str(output_path),
+            provider="groq",
+            model="judge-model",
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        assert result["results"][0]["judgments"] == []
+
+    def test_position_is_deterministic_across_runs(self, tmp_path, monkeypatch) -> None:
+        from eval import judge as jd
+
+        data = self._eval_results(
+            [
+                {"reference_model": "m", "reference_answer": "ref", "error": None},
+            ]
+        )
+        input_path = tmp_path / "eval.json"
+        input_path.write_text(json.dumps(data), encoding="utf-8")
+
+        captured: list[str] = []
+
+        def fake_judge(question: str, a: str, b: str, model: str) -> dict:
+            captured.append(a)
+            return {
+                "score_a": 7.0,
+                "score_b": 5.0,
+                "justification": "ok",
+                "verdict": "A_better",
+            }
+
+        monkeypatch.setattr(jd, "judge_groq", fake_judge)
+
+        for _ in range(2):
+            jd.run_judge(
+                input_path=str(input_path),
+                output_path=str(tmp_path / "out.json"),
+                provider="groq",
+                model="m",
+            )
+
+        # Mesma pergunta → mesma posicao em ambas execucoes
+        assert captured[0] == captured[1]
+
+
+# ============================================================================
+# report
+# ============================================================================
+
+
+@pytest.fixture
+def sample_judged_dataset() -> dict:
+    """Dataset minimo julgado para testar report."""
+    return {
+        "metadata": {
+            "total_questions": 2,
+            "judge_model": "test-model",
+            "judge_provider": "test",
+        },
+        "results": [
+            {
+                "question_id": "q1",
+                "question": "Pergunta de teste 1?",
+                "sb100_answer": "Resposta SB100 1",
+                "reference_answers": [{"reference_model": "modelA", "reference_answer": "Ref A"}],
+                "judgments": [
+                    {
+                        "reference_model": "modelA",
+                        "judge_score": 7,
+                        "reference_score": 5,
+                        "judge_verdict": "better",
+                        "judge_justification": "Justificativa 1",
+                    }
+                ],
+            },
+            {
+                "question_id": "q2",
+                "question": "Pergunta de teste 2?",
+                "sb100_answer": "Resposta SB100 2",
+                "reference_answers": [{"reference_model": "modelB", "reference_answer": "Ref B"}],
+                "judgments": [
+                    {
+                        "reference_model": "modelB",
+                        "judge_score": 4,
+                        "reference_score": 6,
+                        "judge_verdict": "worse",
+                        "judge_justification": "Justificativa 2",
+                    }
+                ],
+            },
+        ],
+    }
+
+
+class TestReport:
+    def test_extract_all_judgments(self, sample_judged_dataset: dict) -> None:
+        judgments = extract_all_judgments(sample_judged_dataset["results"])
+        assert len(judgments) == 2
+        assert judgments[0]["judge_score"] == 7
+
+    def test_extract_skips_none_score(self) -> None:
+        results = [
+            {
+                "question": "Pergunta valida de teste?",
+                "sb100_answer": "a",
+                "reference_answers": [],
+                "judgments": [
+                    {
+                        "reference_model": "m",
+                        "judge_score": None,
+                        "judge_verdict": "error",
+                    }
+                ],
+            }
+        ]
+        assert extract_all_judgments(results) == []
+
+    def test_score_distribution(self, sample_judged_dataset: dict) -> None:
+        judgments = extract_all_judgments(sample_judged_dataset["results"])
+        dist = generate_score_distribution(judgments)
+        assert dist["7-8 (Bom)"] == 1
+        assert dist["3-4 (Fraco)"] == 1
+
+    def test_verdict_stats(self, sample_judged_dataset: dict) -> None:
+        judgments = extract_all_judgments(sample_judged_dataset["results"])
+        stats = generate_verdict_stats(judgments)
+        assert stats["modelA"]["better"] == 1
+        assert stats["modelB"]["worse"] == 1
+
+    def test_generate_report_creates_files(self, tmp_path, sample_judged_dataset: dict) -> None:
+        input_path = tmp_path / "judged.json"
+        report_path = tmp_path / "report.md"
+        sample_path = tmp_path / "sample.csv"
+        input_path.write_text(json.dumps(sample_judged_dataset), encoding="utf-8")
+
+        ok = generate_report(
+            str(input_path),
+            str(report_path),
+            str(sample_path),
+            sample_size=2,
+        )
+
+        assert ok is True
+        assert report_path.exists()
+        assert sample_path.exists()
+        assert "# Relatorio de Avaliacao - SB100" in report_path.read_text(encoding="utf-8")
+
+    def test_generate_report_returns_false_when_empty(self, tmp_path) -> None:
+        empty = {"metadata": {}, "results": []}
+        input_path = tmp_path / "empty.json"
+        input_path.write_text(json.dumps(empty), encoding="utf-8")
+
+        ok = generate_report(
+            str(input_path),
+            str(tmp_path / "report.md"),
+            str(tmp_path / "sample.csv"),
+        )
+
+        assert ok is False
+
+
+# ============================================================================
+# Smoke integrativo: judge -> report
+# ============================================================================
+
+
+class TestPipelineSmoke:
+    def test_judge_to_report_end_to_end(self, tmp_path, monkeypatch) -> None:
+        from eval import judge as jd
+        from eval import report as rp
+
+        questions = [
+            {
+                "question_id": f"q-{i:02d}",
+                "question": f"Pergunta valida de teste numero {i:02d}?",
+                "reference_answers": [
+                    {
+                        "reference_model": "ref-m",
+                        "reference_answer": f"resposta ref {i}",
+                        "error": None,
+                    }
+                ],
+            }
+            for i in range(3)
+        ]
+        eval_results = {
+            "metadata": {"total_questions": 3},
+            "results": [
+                {
+                    **q,
+                    "sb100_answer": f"resposta sb100 {q['question_id']}",
+                    "sb100_hallucination_score": 0.1,
+                    "sb100_session_id": "session-1",
+                    "sb100_success": True,
+                }
+                for q in questions
+            ],
+        }
+        eval_path = tmp_path / "eval.json"
+        judged_path = tmp_path / "judged.json"
+        report_path = tmp_path / "report.md"
+        sample_path = tmp_path / "sample.csv"
+        eval_path.write_text(json.dumps(eval_results), encoding="utf-8")
+
+        monkeypatch.setattr(
+            jd,
+            "judge_groq",
+            lambda q, a, b, m: {
+                "score_a": 7.0,
+                "score_b": 5.0,
+                "justification": "ok",
+                "verdict": "A_better",
+            },
+        )
+
+        jd.run_judge(
+            input_path=str(eval_path),
+            output_path=str(judged_path),
+            provider="groq",
+            model="judge-model",
+        )
+
+        ok = rp.generate_report(
+            str(judged_path),
+            str(report_path),
+            str(sample_path),
+            sample_size=3,
+        )
+
+        assert ok is True
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+        assert "# Relatorio de Avaliacao - SB100" in content


### PR DESCRIPTION
## Título da PR
`feat(eval): TASK-T70 - harden pipeline with abs paths, checkpoint, schema, deterministic A/B`

### 1. Contexto
- **Motivação:** O pipeline `eval/` assumia execução a partir da raiz do repositório (paths relativos quebram em outros CWDs); erros de API eram serializados como `[ERRO] ...` no próprio campo `reference_answer` (mistura sinal com dado); não havia validação entre etapas nem checkpoint (qualquer interrupção em runs longos perdia trabalho); `report.py` retornava exit 0 mesmo quando nenhum relatório era gerado; a alternância A/B em `judge.py` usava `random.random()` (depende de `random.seed`/`PYTHONHASHSEED`).
- **Link da Tarefa:** https://github.com/LukeSantossz/sb100_agents/issues/57
- **Task ref.:** TASK-T70 (`.claude/tasks.md`)

### 2. O que foi feito?
- [x] Novo módulo `eval/_utils.py` com paths absolutos via `Path(__file__).resolve()`, `validate_dataset_schema(data, expected_keys)`, `is_valid_question(q)` (20-500 chars + `?`) e `deterministic_sb100_position_is_a(question_id)` (hash MD5, independente de `PYTHONHASHSEED`).
- [x] `collect_references.py` grava erros como `{reference_model, reference_answer: null, error: str(e)}`; sucesso traz `error: None`.
- [x] `run_evaluation.py` reescrito com checkpoint atômico (`.tmp + replace`) a cada 10 questões; retoma processamento filtrando `question_id`s já feitos; remove o checkpoint ao concluir.
- [x] `judge.py` substitui `random.random() < 0.5` por A/B determinístico via hash do `question_id`; aceita refs legadas (`[ERRO]`) e novas (`error` field); `import random` removido (não mais usado).
- [x] `report.py` retorna `bool`; `main()` exit 1 quando 0 julgamentos válidos.
- [x] Todos os 5 scripts agora usam defaults absolutos baseados em `__file__` (independente de CWD); `validate_dataset_schema` aplicada em todos os entry points.
- [x] `eval/__init__.py` (novo, vazio) torna `eval` package importável nos testes; `pyproject.toml` mantém `eval*` fora do build/coverage.
- [x] `tests/test_eval.py` (novo, 45 testes) cobre helpers, parse, checkpoint (roundtrip/missing/corrupted/atomic), erro estruturado, filtro de erros em judge (novo + legado), determinismo A/B, report (extract/distribution/stats/exit-1) e smoke `judge→report` end-to-end.

### 3. Como testar?
\`\`\`bash
git checkout feat/TASK-T70-eval-hardening
uv sync

# Testes (eval-focused)
.venv/Scripts/python.exe -m pytest tests/test_eval.py -v --no-cov

# Suite completa
.venv/Scripts/python.exe -m pytest tests/ -v --ignore=tests/test_integration.py

# Lint e type check
.venv/Scripts/python.exe -m ruff check .
.venv/Scripts/python.exe -m ruff format --check .
.venv/Scripts/python.exe -m mypy retrieval/ generation/ memory/ --strict --ignore-missing-imports

# Smoke standalone (paths absolutos funcionam de qualquer CWD)
.venv/Scripts/python.exe eval/report.py --help
echo '{"metadata":{},"results":[]}' > /tmp/empty.json
.venv/Scripts/python.exe eval/report.py --input /tmp/empty.json --report /tmp/r.md --sample /tmp/s.csv
echo "exit=\$?"  # deve ser 1
\`\`\`

### 4. Evidências
- `pytest tests/ --ignore=tests/test_integration.py`: **173 passed** (era 136); cobertura **83.07%**.
- `pytest tests/test_integration.py`: 8 passed.
- `ruff check .` + `ruff format --check .`: all checks passed.
- `mypy retrieval/ generation/ memory/ --strict --ignore-missing-imports`: Success — no issues found in 8 source files.
- `eval/report.py` com dataset vazio: `exit=1` confirmado.

### 5. Checklist de Auto-Revisão (base)
- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e console.logs desnecessários
- [x] O código segue o guia de estilo do projeto (PEP8 + ruff)
- [x] As novas dependências funcionam sem quebrar o build atual (sem novas deps)
- [x] Nomes em snake_case (Python) — VAR Method aplicado quando aplicável
- [x] Commits seguem Conventional Commits (sem body, sem co-auth)
- [x] Avaliação pós-implementação foi executada e aprovada

### 6. Checklist Agêntico Estendido (regra 06.1)
> Aplicado por se tratar de código gerado por agente.
- [x] Todo diff foi revisado — nenhum output foi aceito cegamente
- [x] O agente consegue explicar o que cada módulo alterado faz
- [x] Sem coerência superficial: checkpoint testado com missing/corrupted/atomic; determinismo testado em 1000 ids
- [x] Sem abstração excessiva: helpers são funções stdlib (`hashlib`, `pathlib`), sem classes prematuras
- [x] Sem tratamento decorativo de erros: `validate_schema` levanta `ValueError` com mensagem útil; `load_checkpoint` emite warning visível em corrupção; erros de API propagados em campo dedicado
- [x] Sem dependências fantasma: apenas stdlib + pytest existente
- [x] Sem código plausível mas inventado: `tmp.replace(target)` é `pathlib.Path` stdlib; `monkeypatch.setattr` é pytest stdlib
- [x] Sem repetição disfarçada: `sys.path` insertion segue o mesmo padrão nos 5 scripts (consolidação intencional)