### PR TITLE
docs: translate remaining Portuguese comments in Docker YAMLs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,8 @@
 name: Docker Build
 
-# Valida que o Dockerfile multi-stage builda em CI e que a imagem final
-# nao contem build-essential (criterio T71). Trigger so em mudancas
-# relevantes para reduzir custo.
+# Validates that the multi-stage Dockerfile builds in CI and that the final
+# image does not contain build-essential. Triggers only on relevant changes
+# to reduce cost.
 
 on:
   push:
@@ -46,8 +46,8 @@ jobs:
 
       - name: Assert build-essential is NOT in runtime image
         run: |
-          # build-essential aparece no builder stage mas nao deve aparecer no runtime final.
-          # docker history mostra layers; o paginate completo expoe instalacoes apt-get install.
+          # build-essential appears in the builder stage but must not appear in the final runtime.
+          # docker history shows the layers; the full output exposes apt-get install steps.
           if docker history --no-trunc smartb100_api:ci | grep -q "build-essential"; then
             echo "ERROR: build-essential found in final image — multi-stage broken"
             docker history --no-trunc smartb100_api:ci | head -30
@@ -57,7 +57,7 @@ jobs:
 
       - name: Assert curl IS in runtime image (needed for healthchecks)
         run: |
-          # curl precisa estar instalado para os healthchecks do docker-compose funcionarem.
+          # curl must be installed for the docker-compose healthchecks to work.
           docker run --rm --entrypoint sh smartb100_api:ci -c "command -v curl"
 
       - name: Validate compose configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   # ============================================================================
-  # Profile: infra - Servicos de infraestrutura (Qdrant)
-  # Uso: docker compose --profile infra up -d
-  # Nota: Ollama roda localmente (nao via Docker). Veja README.md / SETUP.md.
+  # Profile: infra - Infrastructure services (Qdrant)
+  # Usage: docker compose --profile infra up -d
+  # Note: Ollama runs locally (not via Docker). See README.md / SETUP.md.
   # ============================================================================
 
   qdrant:
@@ -18,8 +18,8 @@ services:
     networks:
       - smartb100_net
     healthcheck:
-      # Qdrant expoe a versao em / com status 200 quando saudavel.
-      # Imagem oficial nao traz curl; usamos /proc/net/tcp como liveness barato.
+      # Qdrant exposes its version at / with status 200 when healthy.
+      # The official image has no curl; /proc/net/tcp is a cheap liveness probe.
       test: ["CMD-SHELL", "grep -q ':18BD' /proc/net/tcp || exit 1"]
       interval: 10s
       timeout: 5s
@@ -32,9 +32,9 @@ services:
         max-file: "3"
 
   # ============================================================================
-  # Profile: app - Servicos de aplicacao (API + Gradio UI)
-  # Uso: docker compose --profile infra --profile app up -d
-  # OLLAMA_HOST override: Linux nativo usa http://172.17.0.1:11434 ou host-net.
+  # Profile: app - Application services (API + Gradio UI)
+  # Usage: docker compose --profile infra --profile app up -d
+  # OLLAMA_HOST override: native Linux uses http://172.17.0.1:11434 or host-net.
   # ============================================================================
 
   api:


### PR DESCRIPTION
## 1. Context

- **Motivation:** The final zero-PT gate on `main` after the adoption PRs found residual Portuguese comments in two YAML files outside PR #141's scope list. This zeroes the gate for good.
- **Task Link:** https://github.com/LukeSantossz/sb100_agents/issues/145
- **Spec Link:** none — comment-only translation across 2 files, below the Spec Gate threshold per `spec_method.md` ("too small to have a design").

## 2. What Was Done

- `docker-compose.yml`: translated the two profile section headers and the Qdrant healthcheck comments.
- `.github/workflows/docker-build.yml`: translated the workflow header (also dropping the historical `T71` task reference, same rule as PR #142) and the two step comments.
- Comment-only: no key, value, trigger, or behavior touched.

## 3. How to Test

1. `git grep -nIiwE "nao|sao|voce|usuario|funcao|configuracao|resposta|pergunta|consulta|arquivo|codigo|metodo|retorna|tambem|porem|entao|exemplo|erro|falha|sucesso|busca|colecao" -- '*.yml'` → no output.
2. `docker compose --profile infra --profile app config` → parses.
3. Docker Build workflow runs on this PR (its `paths` filter includes both files) and must pass.

## 4. Evidence

- Local: YAML PT scan empty (including extra words: uso, nota, expoe, servicos, valida, mudancas, custo); `docker compose config` OK.
- After merge: full accentless-PT gate re-run on `main`, output pasted in this PR — expected to show only the declared survivors (`[ERRO]` data-format marker in eval).

## 5. Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec approved at the Gate before implementation, and the change matches its Scope. (N/A — below Spec Gate threshold; scope recorded in issue #145.)
- [x] Each Acceptance Criterion has a passing verification (comment-only change; gates and Docker Build workflow are the regression net — test-first does not apply).
- [x] Commented-out code and unnecessary debug statements removed (none introduced).
- [x] Code follows the project style guide.
- [x] New dependencies work without breaking the build (none added).
- [x] Review layers recorded:
  - R1 (internal review): ran — Author model Claude (Fable 5).
  - R2 (cross-provider review): not available in this project — human CRURA review stands in.
  - R3 (automated PR review): not configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments for clarity on CI workflow and service configuration. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->