### PR TITLE
fix(ci): correct author gate in claude-respond.yml

### DIFF
--- a/.github/workflows/claude-respond.yml
+++ b/.github/workflows/claude-respond.yml
@@ -10,7 +10,7 @@ jobs:
   respond:
     if: |
       contains(github.event.comment.body, '@claude') &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.sender.association)
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## 1. Context

- **Motivation:** The `Claude Respond` workflow is dead code as written: its author gate evaluates `github.event.sender.association`, a field that does not exist on the `issue_comment` / `pull_request_review_comment` event payloads. The expression resolves to empty, so `contains([...], '')` is always false and the `@claude` responder never fires for anyone — the access control fails closed only by accident.
- **Task Link:** Closes #93
- **Spec Link:** Spec-skipped — single-field correction in one workflow condition, below the design threshold (per `spec_method.md`; precedent PR #146).

## 2. What Was Done

- Replaced `github.event.sender.association` with `github.event.comment.author_association` in the gate at `.github/workflows/claude-respond.yml`. The `comment` object (present on both trigger events) carries the real `author_association` field, restoring the intended `OWNER`/`MEMBER`/`COLLABORATOR` allow-list.

## 3. How to Test

1. Check out the branch.
2. Inspect `.github/workflows/claude-respond.yml`: the `respond` job's `if:` now reads `github.event.comment.author_association`.
3. After merge, an `@claude` comment from a repository OWNER/MEMBER/COLLABORATOR triggers the `respond` job; a comment from an outside user does not.

## 4. Evidence

`TDD-N/A: no test harness for GitHub event payloads; red/green via run evidence.`

- **Red (before):** `github.event.sender.association` is undefined on these events → the gate is permanently false → the workflow has never run on any `@claude` comment.
- **Green (after):** `github.event.comment.author_association` is the documented field on `issue_comment` and `pull_request_review_comment` payloads → the allow-list is evaluated as intended. To be confirmed on the first real `@claude` comment from a privileged author after merge (recorded as a follow-up comment on this PR).

## 5. Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec gate: spec-skip justified above (single-field YAML correction, no design).
- [x] Test-first: `TDD-N/A` (category B — GitHub event payloads have no local harness); red/green documented via run evidence.
- [x] Commented-out code and debug statements removed (none introduced).
- [x] Code follows the project style guide.
- [x] No new dependencies.
- [x] Review layers: **R1 internal (Author: Claude Opus) ran** via self-review. **R2 cross-provider: not available in this project** — human CRURA review stands in. **R3 automated PR review: not configured.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow authorization logic to use improved comment author verification for response automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->