### PR TITLE
fix(deps): bump starlette to 1.3.0 for Host header validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1010,9 +1010,9 @@ sqlalchemy==2.0.49 \
     --hash=sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0 \
     --hash=sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982
     # via smartb100
-starlette==0.52.1 \
-    --hash=sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74 \
-    --hash=sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933
+starlette==1.3.0 \
+    --hash=sha256:bb58cbb7a699da4ee4be9ed4cdfe4bc5b0390aa6dac1d1ac714ebebe8dc3c8df \
+    --hash=sha256:ff4ca1bc23de6a45cdfbbeb9b3caaea524c9221cdd8a6684ad7a4f651a83890b
     # via
     #   fastapi
     #   gradio

--- a/uv.lock
+++ b/uv.lock
@@ -1808,15 +1808,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/37/cc24e33974e1439cf5ca62b0735b63026eabb768f472d8775f52d5851ed9/starlette-1.3.0.tar.gz", hash = "sha256:bb58cbb7a699da4ee4be9ed4cdfe4bc5b0390aa6dac1d1ac714ebebe8dc3c8df", size = 2702493, upload-time = "2026-06-11T06:27:41.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/16/42/56d31c5ee52dab0ad893d67d4f9c00f5ba2b4c5d87f392eca2c3fdce01cf/starlette-1.3.0-py3-none-any.whl", hash = "sha256:ff4ca1bc23de6a45cdfbbeb9b3caaea524c9221cdd8a6684ad7a4f651a83890b", size = 73492, upload-time = "2026-06-11T06:27:40.444Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 1. Context

- **Motivation:** Two open Dependabot alerts (GHSA-86qp-5c8j-p5mr) flag that the pinned `starlette==0.52.1` is missing Host header validation, which poisons `request.url.path` and can bypass path-based security checks. The advisory's vulnerable range is `<= 1.0.0`; the first patched version is `1.0.1`. Because the fix exists **only in the 1.x line**, the correction is necessarily a major-version bump, not a patch within 0.x.
- **Task Link:** Closes #135
- **Spec Link:** Spec-skipped — lockfile bump plus mechanical `requirements.txt` re-export, with no design choice (the patched version range is dictated by the advisory and the resolver). Note: the change turned out to be a **major** bump (0.x → 1.x); the spec-skip is retained because there is still no design space, but the verification below is treated as the gate.

## 2. What Was Done

- `uv lock --upgrade-package starlette` → `starlette` moves `0.52.1` → `1.3.0` (latest 1.x, ≥ the patched `1.0.1`). `fastapi==0.135.1` and `gradio==6.13.0` already permit starlette 1.x, so the resolver kept all 90 packages with only `starlette` changing.
- `uv export --frozen --no-dev -o requirements.txt` re-exported the pin (keeps the CI `validate-requirements` job green). The `requirements.txt` diff is exactly the `starlette` version line and its two hashes (3 lines).

## 3. How to Test

1. Check out the branch.
2. `uv sync --extra dev`.
3. `uv run pytest tests/ --ignore=tests/test_integration.py` — full suite passes.
4. `uv export --frozen --no-dev -o requirements.txt && git diff --quiet requirements.txt` — no diff (requirements in sync), the same invariant CI enforces.

## 4. Evidence

Verified locally on the dev host (Windows, uv 0.11.0, Python 3.12):

- **Compatibility (the real risk of a 0.x → 1.x bump):** full suite **210 passed** with `starlette==1.3.0`; the fully-mocked integration file additionally **8 passed**. `ruff check .` → all checks passed; `ruff format --check .` → 50 files already formatted; `mypy retrieval/ generation/ memory/ --ignore-missing-imports` → clean.
- **Requirements sync:** re-export produces no further diff; the only change vs `main` is `starlette==0.52.1 \` → `starlette==1.3.0 \` plus its hashes.
- **Alert closure:** both Dependabot alerts for GHSA-86qp-5c8j-p5mr should auto-close on merge (current `1.3.0` ≥ first-patched `1.0.1`).

## 5. Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec gate: spec-skip justified above; the major-bump risk is covered by the full-suite verification serving as the gate.
- [x] Test-first: existing suite (218 tests) is the regression gate for a dependency bump; no production logic changed, so no new test is written (writing one would only re-state the suite).
- [x] Commented-out code and debug statements removed (none introduced).
- [x] Code follows the project style guide.
- [x] New dependency version works without breaking the build (suite + lint + types green).
- [x] Review layers: **R1 internal (Author: Claude Opus) ran** via self-review. **R2 cross-provider: not available in this project** — human CRURA review stands in. **R3 automated PR review: not configured.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal web framework dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->