### PR TITLE
fix(chat): rate-limit POST /chat per authenticated user (#110)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,11 @@ CHAT_TIMEOUT=600
 # Bounds: 1-600 (kept under CHAT_TIMEOUT).
 OLLAMA_TIMEOUT=240
 
+# Per-user rate limit for POST /chat (slowapi format "<count>/<interval>").
+# Keyed by the JWT subject, not the IP: caps how often one authenticated user
+# can trigger the costly RAG + paid-verification pipeline. Exceeding it -> 429.
+CHAT_RATE_LIMIT=30/minute
+
 # LLM provider for sample generation in hallucination verification.
 # Options: groq (default, fast), ollama (local), openrouter
 VERIFICATION_PROVIDER=groq

--- a/SPEC.md
+++ b/SPEC.md
@@ -30,7 +30,7 @@ Apply slowapi's `@limiter.limit` to `chat()` with a **per-user** key derived fro
 ## Reproducibility
 
 - Versions: Python 3.12, slowapi (already a dependency), on the dev host.
-- Unit (no infra): `uv run pytest tests/test_auth.py tests/test_integration.py -v` — assert `_rate_limit_key` on a crafted token; drive `TestClient` against `/chat` (external services mocked, `verify_token` overridden) with a low `chat_rate_limit` and assert the (limit+1)-th call returns 429.
+- Unit (no infra): `uv run pytest tests/test_chat_rate_limit.py tests/test_auth.py tests/test_integration.py -v` — assert `_rate_limit_key` on a crafted token; drive `TestClient` against `/chat` (external services mocked, `verify_token` overridden) with a low `chat_rate_limit` and assert the (limit+1)-th call returns 429.
 
 ## Risks and Assumptions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,39 @@
+# SPEC: fix(chat): rate-limit POST /chat per authenticated user (DoS / cost amplification)
+
+## Problem
+
+`POST /chat` — the system's most expensive endpoint (each call fans out to Ollama generations plus, by default, multiple paid Groq/OpenRouter verification calls) — has no rate limit, while `/auth/*` already use slowapi; a 7-day token lets one authenticated user loop `/chat` and exhaust the paid quota and saturate local inference (OWASP A04 / CWE-770).
+
+## Design Decision
+
+Apply slowapi's `@limiter.limit` to `chat()` with a **per-user** key derived from the authenticated request, not the client IP. A module-level `_rate_limit_key(request)` reads the bearer token from the `Authorization` header and returns its JWT `sub` (username); it falls back to `get_remote_address` when no valid token is present (those requests are 401'd by `verify_token` anyway). The limit is configurable via a new `chat_rate_limit` setting (default `"30/minute"`); exceeding it returns 429 (slowapi's handler is already registered for `/auth`). `chat()` gains the `request: Request` parameter slowapi requires.
+
+## Alternatives Considered
+
+1. **Per-IP limit (slowapi's default `get_remote_address`).** Rejected: many users behind one NAT share a limit and one user across IPs evades it; the expensive resource is per-identity, so the key must be the user.
+2. **A daily paid-provider call budget / shedding the entropy gate under load.** Deferred (not this PR): a global cost-budget is a larger quota subsystem; the surgical, high-value fix is the per-user request rate limit. Recorded as future hardening.
+3. **Shorten the token TTL to bound abuse.** Rejected: wrong layer (auth lifetime ≠ request throttling) and it would not bound burst cost within a single session.
+
+## Scope
+
+- **Includes:** a per-user `@limiter.limit` on `POST /chat` keyed by the JWT subject (IP fallback); the `request: Request` parameter on the handler; a configurable `chat_rate_limit` setting documented in `.env.example`; 429 on exceed. Changes confined to `api/routes/chat.py`, `core/config.py`, `.env.example`.
+- **Does NOT include:** the IDOR per-user session scoping (#108); a daily/global paid-provider budget or load-shedding of the entropy gate (future hardening, no dedicated issue); any change to token TTL or the `/auth` limits; async cancellation of timed-out work (related to #99).
+
+## Acceptance Criteria
+
+- `rate_limit_key_returns_jwt_subject` — `_rate_limit_key` returns the token's `sub` for an authenticated request; two users yield different keys, the same user the same key.
+- `rate_limit_key_falls_back_to_ip_without_token` — with a missing/invalid `Authorization` header, the key is the client address (no exception).
+- `chat_is_decorated_with_a_per_user_limit` — `POST /chat` enforces `settings.chat_rate_limit` rather than the default IP limiter.
+- `exceeding_the_limit_returns_429` — the (N+1)-th request within the window returns 429.
+- No regression: existing tests pass (`pytest tests/ --ignore=tests/test_integration.py`).
+
+## Reproducibility
+
+- Versions: Python 3.12, slowapi (already a dependency), on the dev host.
+- Unit (no infra): `uv run pytest tests/test_auth.py tests/test_integration.py -v` — assert `_rate_limit_key` on a crafted token; drive `TestClient` against `/chat` (external services mocked, `verify_token` overridden) with a low `chat_rate_limit` and assert the (limit+1)-th call returns 429.
+
+## Risks and Assumptions
+
+- Assumption: the slowapi `limiter` and its 429 handler are app-wired (confirmed — `/auth` uses `@limiter.limit`, `api/dependencies.py:27`); only a newly decorated route is added.
+- Assumption: decoding the JWT in the key function uses the same `settings.jwt_secret_key`/`ALGORITHM` as `verify_token`; an invalid token falls back to IP rather than raising inside the limiter.
+- Risk: slowapi's default in-memory storage is per-process, so in a multi-worker deployment the limit is per worker; acceptable for the current single-process target, with a shared store (e.g. Redis) as a future scaling concern.

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -19,9 +19,12 @@ import threading
 import time
 from collections import OrderedDict
 
-from fastapi import APIRouter, Depends, HTTPException
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Request
+from jwt.exceptions import InvalidTokenError
+from slowapi.util import get_remote_address
 
-from api.dependencies import verify_token
+from api.dependencies import ALGORITHM, limiter, verify_token
 from core.config import settings
 from core.schemas import ChatRequest, ChatResponse
 from database.models import User
@@ -86,8 +89,42 @@ def _get_or_create_buffer(session_id: str) -> ConversationBuffer:
         return buffer
 
 
+def _rate_limit_key(request: Request) -> str:
+    """Rate-limit bucket for POST /chat: the authenticated user, IP as fallback.
+
+    The expensive resource (Ollama generation plus paid verification calls) is
+    consumed per identity, so the limit is keyed on the JWT ``sub`` rather than
+    the client IP: users behind one NAT must not share a budget, and one user
+    must not evade it by rotating IPs. A request whose bearer token is missing
+    or undecodable falls back to the client address — ``verify_token`` rejects
+    it with 401 before the handler body runs anyway.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    scheme, _, token = auth_header.partition(" ")
+    if scheme.lower() == "bearer" and token:
+        try:
+            payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[ALGORITHM])
+        except InvalidTokenError:
+            return str(get_remote_address(request))
+        subject = payload.get("sub")
+        if isinstance(subject, str) and subject:
+            return subject
+    return str(get_remote_address(request))
+
+
+def _chat_rate_limit() -> str:
+    """Per-user limit for POST /chat, read at request time.
+
+    Provided as a callable so the value tracks ``settings.chat_rate_limit``
+    instead of being frozen at import time (e.g. when reconfigured in tests).
+    """
+    return settings.chat_rate_limit
+
+
 @router.post("", response_model=ChatResponse)
+@limiter.limit(_chat_rate_limit, key_func=_rate_limit_key)
 def chat(
+    request: Request,
     req: ChatRequest,
     current_user: User = Depends(verify_token),
 ) -> ChatResponse:
@@ -101,6 +138,7 @@ def chat(
     5. Update the conversation history.
 
     Args:
+        request: HTTP request (required by the slowapi per-user rate limit).
         req: Request containing session_id, question and profile.
         current_user: Authenticated user (injected by ``verify_token``).
 
@@ -109,6 +147,7 @@ def chat(
 
     Raises:
         HTTPException(401): If the JWT is missing, invalid or expired.
+        HTTPException(429): If the per-user rate limit is exceeded.
         HTTPException(503): If Ollama or Qdrant are unavailable.
     """
     logger.info(

--- a/core/config.py
+++ b/core/config.py
@@ -61,6 +61,8 @@ class Settings(BaseSettings):
     ollama_timeout: float = Field(default=240.0, ge=1.0, le=600.0)
     ollama_embed_timeout: float = Field(default=5.0, ge=1.0, le=120.0)
     chat_timeout: float = Field(default=600.0, ge=1.0, le=3600.0)
+    # slowapi limit string enforced per authenticated user on POST /chat.
+    chat_rate_limit: str = "30/minute"
     groq_api_key: str | None = None
     openrouter_api_key: str | None = None
     jwt_secret_key: str = ""

--- a/core/config.py
+++ b/core/config.py
@@ -13,6 +13,7 @@ Usage example:
 
 from enum import StrEnum
 
+from limits import parse_many
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -66,6 +67,24 @@ class Settings(BaseSettings):
     groq_api_key: str | None = None
     openrouter_api_key: str | None = None
     jwt_secret_key: str = ""
+
+    @field_validator("chat_rate_limit")
+    @classmethod
+    def _validate_chat_rate_limit(cls, value: str) -> str:
+        """Reject an empty or malformed rate-limit string at startup.
+
+        slowapi parses this lazily on the first request, so an invalid
+        ``CHAT_RATE_LIMIT`` would otherwise surface as a 500 on every ``/chat``
+        call instead of a fail-loud boot error. Validating the slowapi format
+        here (via the same ``limits`` parser slowapi uses) catches it early.
+        """
+        try:
+            parse_many(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"CHAT_RATE_LIMIT must be a slowapi limit string like '30/minute' (got {value!r})"
+            ) from exc
+        return value
 
     @field_validator("jwt_secret_key")
     @classmethod

--- a/tests/test_chat_rate_limit.py
+++ b/tests/test_chat_rate_limit.py
@@ -1,0 +1,139 @@
+"""Tests for the per-user rate limit on POST /chat (#110).
+
+Covers the SPEC acceptance criteria: the limit key derives from the JWT
+subject (with a client-IP fallback), and POST /chat returns 429 once a user
+exceeds ``settings.chat_rate_limit`` — enforced independently per user.
+"""
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from api.dependencies import limiter, verify_token
+from api.main import app
+from api.routes.auth import create_access_token
+from api.routes.chat import _rate_limit_key, _sessions
+from core.config import settings
+from database.models import User
+
+CLIENT_IP = "203.0.113.7"
+
+
+def _make_request(headers: dict[str, str], client_host: str = CLIENT_IP) -> Request:
+    """Build a minimal ASGI ``Request`` carrying the given headers and client."""
+    raw_headers = [(key.lower().encode(), value.encode()) for key, value in headers.items()]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/chat",
+        "headers": raw_headers,
+        "client": (client_host, 12345),
+    }
+    return Request(scope)
+
+
+def _bearer(subject: str) -> dict[str, str]:
+    """Authorization header carrying a valid JWT for ``subject``."""
+    token = create_access_token({"sub": subject}, expires_delta=timedelta(minutes=5))
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ----------------------------- _rate_limit_key -----------------------------
+
+
+def test_rate_limit_key_returns_jwt_subject() -> None:
+    """The key is the token's ``sub``: distinct users differ, the same user matches."""
+    key_alice = _rate_limit_key(_make_request(_bearer("alice")))
+    key_alice_again = _rate_limit_key(_make_request(_bearer("alice")))
+    key_bob = _rate_limit_key(_make_request(_bearer("bob")))
+
+    assert key_alice == "alice"
+    assert key_alice == key_alice_again
+    assert key_alice != key_bob
+
+
+def test_rate_limit_key_falls_back_to_ip_without_token() -> None:
+    """A missing or invalid bearer token yields the client address, no exception."""
+    missing = _rate_limit_key(_make_request({}, client_host="198.51.100.4"))
+    invalid = _rate_limit_key(
+        _make_request({"Authorization": "Bearer not-a-jwt"}, client_host="198.51.100.4")
+    )
+
+    assert missing == "198.51.100.4"
+    assert invalid == "198.51.100.4"
+
+
+# ----------------------------- POST /chat 429 -----------------------------
+
+
+def _override_verify_token() -> User:
+    """JWT gate stub — returns a fixed user without hitting the database."""
+    return User(id=1, username="testuser", hashed_password="x", created_at=datetime.now(UTC))
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> Generator[None, None, None]:
+    """Start each test with an empty session cache and clean limiter storage."""
+    _sessions.clear()
+    limiter.reset()
+    yield
+    _sessions.clear()
+    limiter.reset()
+
+
+@pytest.fixture
+def low_chat_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lower the per-user chat limit so the threshold is cheap to exercise."""
+    monkeypatch.setattr(settings, "chat_rate_limit", "3/minute")
+
+
+@pytest.fixture
+def chat_client() -> Generator[TestClient, None, None]:
+    """TestClient with the JWT gate and RAG pipeline mocked (no real infra)."""
+    app.dependency_overrides[verify_token] = _override_verify_token
+    with (
+        patch("api.routes.chat.generate_embedding", return_value=[0.1] * 768),
+        patch("api.routes.chat.search_context", return_value=["chunk"]),
+        patch("api.routes.chat.generate", return_value="answer"),
+        patch.object(settings, "verification_enabled", False),
+    ):
+        try:
+            yield TestClient(app)
+        finally:
+            app.dependency_overrides.clear()
+
+
+_PAYLOAD = {
+    "session_id": "rl-session",
+    "question": "How to correct soil acidity?",
+    "profile": {"name": "TestUser", "expertise": "beginner"},
+}
+
+
+def test_exceeding_the_limit_returns_429(chat_client: TestClient, low_chat_limit: None) -> None:
+    """The (limit + 1)-th request from one user within the window returns 429."""
+    headers = _bearer("heavy-user")
+
+    for _ in range(3):
+        allowed = chat_client.post("/chat", json=_PAYLOAD, headers=headers)
+        assert allowed.status_code == 200
+
+    blocked = chat_client.post("/chat", json=_PAYLOAD, headers=headers)
+    assert blocked.status_code == 429
+
+
+def test_limit_is_per_user_not_per_ip(chat_client: TestClient, low_chat_limit: None) -> None:
+    """One user exhausting the budget does not throttle another (same client IP)."""
+    for _ in range(3):
+        assert (
+            chat_client.post("/chat", json=_PAYLOAD, headers=_bearer("user-a")).status_code == 200
+        )
+    assert chat_client.post("/chat", json=_PAYLOAD, headers=_bearer("user-a")).status_code == 429
+
+    # A different identity from the same TestClient host keeps a full budget,
+    # which a per-IP limit would not allow.
+    assert chat_client.post("/chat", json=_PAYLOAD, headers=_bearer("user-b")).status_code == 200

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,3 +190,22 @@ def test_ollama_timeout_rejects_over_max() -> None:
     # The le=600.0 bound (headroom under chat_timeout) stays enforced.
     with pytest.raises(ValidationError):
         Settings(**_kwargs(ollama_timeout=601.0))
+
+
+# ----------------------------- chat_rate_limit (#110) -----------------------------
+
+
+def test_chat_rate_limit_rejects_empty() -> None:
+    # An empty CHAT_RATE_LIMIT must fail at startup, not on the first /chat call.
+    with pytest.raises(ValidationError):
+        Settings(**_kwargs(chat_rate_limit=""))
+
+
+def test_chat_rate_limit_rejects_malformed() -> None:
+    with pytest.raises(ValidationError):
+        Settings(**_kwargs(chat_rate_limit="not-a-limit"))
+
+
+def test_chat_rate_limit_accepts_valid_slowapi_format() -> None:
+    s = Settings(**_kwargs(chat_rate_limit="10/second"))
+    assert s.chat_rate_limit == "10/second"


### PR DESCRIPTION
## 1. Context

- **Motivation:** `POST /chat` is the costliest endpoint (each call fans out to Ollama generation plus, by default, paid Groq/OpenRouter verification) yet had no rate limit, while `/auth/*` already use slowapi. A 7-day token let one authenticated user loop `/chat` to exhaust the paid quota and saturate local inference (OWASP A04 / CWE-770).
- **Task Link:** #110
- **Spec Link:** [`SPEC.md` on this branch](https://github.com/LukeSantossz/sb100_agents/blob/fix/110-rate-limit-chat/SPEC.md) (kept on the branch; removed as the final commit before merge).

## 2. What Was Done

- Added `_rate_limit_key(request)` in `api/routes/chat.py`: returns the JWT `sub` (per-user key), falling back to the client IP when no valid bearer token is present (those requests are 401'd by `verify_token` anyway).
- Decorated `POST /chat` with `@limiter.limit(_chat_rate_limit, key_func=_rate_limit_key)` — the slowapi `limiter` and its 429 handler were already wired for `/auth`. `chat()` gains the `request: Request` parameter slowapi requires.
- Added the configurable `chat_rate_limit` setting (`core/config.py`, default `"30/minute"`) and documented `CHAT_RATE_LIMIT` in `.env.example`.
- Exceeding the limit returns **429**; the limit is keyed per identity, so users behind one NAT do not share a budget and one user cannot evade it across IPs.

Changes confined to the spec's scope: `api/routes/chat.py`, `core/config.py`, `.env.example` (plus the new test module).

## 3. How to Test

1. Check out `fix/110-rate-limit-chat`.
2. `uv sync`
3. Rate-limit tests: `uv run pytest tests/test_chat_rate_limit.py -o addopts="" -v` — 4 tests (key = JWT subject, IP fallback, 429 on exceed, per-user isolation).
4. CI-parity suite: `uv run --with pytest-cov pytest tests/ --ignore=tests/test_integration.py` — 251 passed, no regression.

## 4. Evidence

Backend/configuration only — no UI change. The 429 path is covered by `tests/test_chat_rate_limit.py::test_exceeding_the_limit_returns_429`, and per-user (not per-IP) keying by `test_limit_is_per_user_not_per_ip`.

## 5. Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec approved at the Gate before implementation, and the change matches its Scope (per `spec_method.md`).
- [x] Each Acceptance Criterion has a passing test; tests were written before their implementation (test commit `12b3d95` precedes fix commit `469b461`).
- [x] No commented-out code or debug statements.
- [x] Code follows the project style guide (`ruff check` and `ruff format --check` clean).
- [x] No new dependencies (slowapi already present).
- Review layers recorded:
  - **R1 (internal review):** ran — Claude Code internal self-review.
  - **R2 (cross-provider review):** not available in this project — human CRURA review stands in (per project `CLAUDE.md`).
  - **R3 (automated PR review):** not configured.

## Notes / Risks

- slowapi's default in-memory storage is per-process, so in a multi-worker deployment the limit is per worker; acceptable for the current single-process target, with a shared store (e.g. Redis) recorded as a future scaling concern.
- Out of scope (deferred): the IDOR per-user session scoping (#108), a global paid-provider budget, token-TTL changes, and async cancellation of timed-out work (#99).

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2WVdsBfYFyUGoGSMxDo83)_